### PR TITLE
oauth.js: use params supplied by provider for profile retrieval

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -214,7 +214,7 @@ exports.v2 = function (settings) {
                     Hoek.merge(getOptions.headers, settings.provider.headers);
                 }
 
-                var query = (params ? '?' + Querystring.encode(query) : '');
+                var query = (params ? '?' + Querystring.encode(params) : '');
                 Nipple.get(uri + query, getOptions, function (err, res, response) {
 
                     if (err ||


### PR DESCRIPTION
Hi, I believe this is just a typo.
