### PR TITLE
Bump peer dependency to Hapi >= 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "joi": "^4.6.x"
   },
   "peerDependencies": {
-    "hapi": ">=2.x.x"
+    "hapi": ">=6.x.x"
   },
   "devDependencies": {
     "hapi": "6.x.x",


### PR DESCRIPTION
Yesterday I thought I'd convert our _Hapi 4.1_ app (held there by _Travelogue_) over to _Bell_. A glance at the _peerDependencies_ made me think this was a good idea. _peerDependencies_ handling in _npm_ isn't solid, but _Bell_ definitely needs _Hapi >= 6_ because of `server.location()` in `oauth.js`. 

This is just a proposal that the `README.md` or `package.json` indicate that.

Thanks for spearheading this, @hueniverse.It solves a lot of annoyances we've had with OAuth frameworks.
