### PR TITLE
Added ability to specify additional query params for the profile request...

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Each strategy accepts the following optional settings:
   option which allows disabling the extra profile request when the provider returns the user information in the callback (defaults to `true`).
   The built-in `'github'` provider accepts the `uri` option which allows pointing to a private enterprise installation
   (e.g. `'https://vpn.example.com'`).
-- `additionalParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
+- `profileParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ internals.schema = Joi.object({
     scope: Joi.array().includes(Joi.string()).when('provider.protocol', { is: 'oauth2', otherwise: Joi.forbidden() }),
     name: Joi.string().required(),
     config: Joi.object(),
-    additionalParams: Joi.object()
+    profileParams: Joi.object()
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -91,6 +91,10 @@ exports.v1 = function (settings) {
 
             var get = function (uri, params, callback) {
 
+                if (settings.profileParams) {
+                    Hoek.merge(params, settings.profileParams);
+                }
+
                 return client.get(uri, params, payload.oauth_token, payload.oauth_token_secret, function (err, response) {
 
                     if (err) {
@@ -210,8 +214,8 @@ exports.v2 = function (settings) {
                     }
                 };
 
-                if (settings.additionalParams) {
-                    Hoek.merge(params, settings.additionalParams);
+                if (settings.profileParams) {
+                    Hoek.merge(params, settings.profileParams);
                 }
 
                 if (settings.provider.headers) {


### PR DESCRIPTION
... to the provider

I did so because I wanted to be able to get the user's profile picture from Facebook. I believe this gives a scalable way to do this, and I've tested it within my project to work as intended with that use case.

Tests included, verified 100% code coverage with `npm test` and updated the README to explain usage.
