### PR TITLE
handle oauth user rejection for v2 as well

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -127,6 +127,11 @@ exports.v2 = function (settings) {
         var cookie = settings.cookie;
         var name = settings.name;
 
+        // Bail if the upstream service returns an error
+        if (request.query.error === 'access_denied' || request.query.denied) {
+          return reply(Boom.internal('App was rejected'));
+        }
+
         // Sign-in Initialization
 
         if (!request.query.code) {

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -923,6 +923,47 @@ describe('Bell', function () {
             });
         });
 
+        it('errors on rejected query parameter', function (done) {
+
+            var mock = new Mock.V2();
+            mock.start(function (provider) {
+
+                var server = new Hapi.Server('localhost');
+                server.pack.register(Bell, function (err) {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: false,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        providerParams: { special: true }
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: function (request, reply) {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login?error=access_denied', function (res) {
+
+                        expect(res.statusCode).to.equal(500);
+                        done();
+
+                    });
+                });
+            });
+        });
+
         it('passes profile get params', { parallel: false }, function (done) {
 
             var mock = new Mock.V2();


### PR DESCRIPTION
This is related to https://github.com/hapijs/bell/issues/23

We have to handle this case in the v2 protocol (e.g. facebook) as well.
