### PR TITLE
update example for hapi 8.0.0

### DIFF
--- a/examples/twitter.js
+++ b/examples/twitter.js
@@ -4,8 +4,10 @@ var Hapi = require('hapi');
 var Bell = require('../');
 
 
-var server = new Hapi.Server(8000);
-server.pack.register(Bell, function (err) {
+var server = new Hapi.Server();
+server.connection({ port: 8000 });
+
+server.register(Bell, function (err) {
 
     server.auth.strategy('twitter', 'bell', {
         provider: 'twitter',


### PR DESCRIPTION
Presently, the published version of bell requires hapi 8.0.0, so might as well update the example accordingly.
