### PR TITLE
Add comment in Twitter example to clarify required Twitter app settings

### DIFF
--- a/examples/twitter.js
+++ b/examples/twitter.js
@@ -13,6 +13,9 @@ server.register(Bell, function (err) {
         provider: 'twitter',
         password: 'password',
         isSecure: false,
+        // Make sure to set a "Callback URL" and
+        // check the "Allow this application to be used to Sign in with Twitter"
+        // on the "Settings" tab in your Twitter application
         clientId: '',                               // Set client id
         clientSecret: ''                            // Set client secret
     });


### PR DESCRIPTION
Add comment in Twitter example that "Callback URL" and "Allow this application to be used to Sign in with Twitter" are required for the script to work.
