### PR TITLE
Add option for forcing https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The `server.auth.strategy()` method requires the following strategy options:
   protocol steps.
 - `clientId` - the OAuth client identifier (consumer key).
 - `clientSecret` - the OAuth client secret (consumer secret).
+- `forceHttps` - A boolean indicating whether or not you want the redirect_uri to be forced to https. Useful if your hapi application runs as http, but is accessed through https.
 
 Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to `'bell-provider'` where 'provider' is the provider name
@@ -170,5 +171,3 @@ server.register(require('bell'), function (err) {
     server.start();
 });
 ```
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,8 @@ internals.schema = Joi.object({
     scope: Joi.array().includes(Joi.string()).when('provider.protocol', { is: 'oauth2', otherwise: Joi.forbidden() }),
     name: Joi.string().required(),
     config: Joi.object(),
-    profileParams: Joi.object()
+    profileParams: Joi.object(),
+    forceHttps: Joi.boolean().optional().default(false)
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -135,6 +135,10 @@ exports.v2 = function (settings) {
           return reply(Boom.internal('App was rejected'));
         }
 
+        // Alter the request to be able to force HTTPS.
+        if (settings.forceHttps) {
+            request.connection.info.protocol = 'https';
+        }
         // Sign-in Initialization
 
         if (!request.query.code) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -135,18 +135,18 @@ exports.v2 = function (settings) {
           return reply(Boom.internal('App was rejected'));
         }
 
-        // Alter the request to be able to force HTTPS.
-        if (settings.forceHttps) {
-            request.connection.info.protocol = 'https';
-        }
         // Sign-in Initialization
 
         if (!request.query.code) {
             var nonce = Cryptiles.randomString(22);
             var query = Hoek.clone(settings.providerParams) || {};
+            var protocol = request.connection.info.protocol;
+            if (settings.forceHttps) {
+              protocol = 'https';
+            }
             query.client_id = settings.clientId;
             query.response_type = 'code';
-            query.redirect_uri = internals.location(request);
+            query.redirect_uri = internals.location(request, protocol);
             query.state = nonce;
 
             var scope = settings.scope || settings.provider.scope;
@@ -488,9 +488,9 @@ internals.parse = function (payload) {
 };
 
 
-internals.location = function (request) {
-    
+internals.location = function (request, protocol) {
     var info = request.connection.info;
+    protocol = protocol || info.protocol;
     var host = request.info.host || (info.host + ':' + info.port);
-    return info.protocol + '://' + host + request.path;
+    return protocol + '://' + host + request.path;
 };


### PR DESCRIPTION
As mentioned in #40, this is a PR adding the option to force https in redirect_uri.

Granted, it might not be the best solution to alter the request object like this, but this certainly works. The other option would be to pass in the settings as a parameter to the location function, not sure which one you prefer? IMO the naming of the option (force) indicates some force, and thus we are forcing the request object to be https :)

PR also adds a test for this.