### PR TITLE
passing back expires_in for oauth 2.0 refresh token request

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Another way to handle authentication errors is within the route handler. By defa
 skipped. However, if the authentication mode is set to `'try'` instead of `'required'`, the handler will still be called. In this case,
 the `request.auth.isAuthenticated` must be checked to test if authentication failed. In that case, `request.auth.error` will contain the error.
 
+#### Token Refresh
+
+To keep track of the token expiry time, `request.auth.credentials.expiresIn` provides you the duration (in seconds) after which you could send a refresh token request using the `request.auth.credentials.refreshToken` to get a new token.
+
 ```javascript
 var Hapi = require('hapi');
 var server = new Hapi.Server(8000);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -215,6 +215,7 @@ exports.v2 = function (settings) {
                 provider: name,
                 token: payload.access_token,
                 refreshToken: payload.refresh_token,
+                expiresIn: payload.expires_in,
                 query: state.query
             };
 

--- a/test/providers.js
+++ b/test/providers.js
@@ -80,6 +80,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -161,6 +162,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -234,6 +236,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -312,6 +315,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -397,6 +401,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -478,6 +483,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -556,6 +562,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -635,6 +642,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -710,6 +718,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -775,6 +784,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -848,6 +858,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -938,6 +949,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1028,6 +1040,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1106,6 +1119,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -1171,6 +1185,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -1194,7 +1209,7 @@ describe('Bell', function () {
             });
         });
     });
-    
+
     describe('#vk', function () {
 
         it('authenticates with mock', { parallel: false }, function (done) {
@@ -1210,7 +1225,7 @@ describe('Bell', function () {
 
                     var custom = Bell.providers.vk();
                     Hoek.merge(custom, provider);
-                    
+
                     var data = {
                         response: [{
                             uid: '1234567890',
@@ -1249,6 +1264,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: {
@@ -1271,7 +1287,7 @@ describe('Bell', function () {
             });
         });
     });
-    
+
     describe('#bitbucket', function () {
 
         it('authenticates with mock', { parallel: false }, function (done) {
@@ -1327,6 +1343,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1408,6 +1425,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
+                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1491,6 +1509,7 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: '456',
+                                    expiresIn: 3600,
                                     refreshToken: undefined,
                                     query: {},
                                     profile: profile


### PR DESCRIPTION
As discussed in the issues here: https://github.com/hapijs/bell/issues/49 the pull request has been submitted.
