### PR TITLE
Added protocol option to the auth_callback

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -37,8 +37,12 @@ exports.v1 = function (settings) {
         if (!request.query.oauth_token) {
 
             // Obtain temporary OAuth credentials
+            var protocol = request.connection.info.protocol;
+            if (settings.forceHttps) {
+                protocol = 'https';
+            }
 
-            var oauth_callback = internals.location(request);
+            var oauth_callback = internals.location(request, protocol);
             return client.temporary(oauth_callback, function (err, payload) {
 
                 if (err) {


### PR DESCRIPTION
After some debugging I found forceHttps wasn't actually working and one of the internals.location() calls was missing the protocol parameter. So simply adding that in seems to have resolved the issue hence the PR.

This was debugged and referenced in #40.