### PR TITLE
Support phabricator third party provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### **bell**
 
 **bell** is a third-party login plugin for [hapi](https://github.com/hapijs/hapi). **bell** ships with built-in support for Facebook, GitHub,
-Google, Instagram, LinkedIn, Twitter, Yahoo, Foursquare, VK, ArcGIS Online and Windows Live. It also supports any compliant OAuth 1.0a and 2.0 based login services with a simple configuration object.
+Google, Instagram, LinkedIn, Twitter, Yahoo, Foursquare, VK, ArcGIS Online, Windows Live, and Phabricator. It also supports any compliant OAuth 1.0a and 2.0 based login services with a simple configuration object.
 
 [![Build Status](https://secure.travis-ci.org/hapijs/bell.png)](http://travis-ci.org/hapijs/bell)
 
@@ -65,7 +65,7 @@ server.register(require('bell'), function (err) {
 ### Options
 
 The `server.auth.strategy()` method requires the following strategy options:
-- `provider` - the name of the third-party provider (`'bitbucket'`, `'dropbox'`, `'facebook'`, `'foursquare'`, `'github'`, `'google'`, `'instagram'`, `'linkedin'`, `'live'`, `'twitter'`, `'vk'`, `'arcgisonline'`, `'yahoo'`)
+- `provider` - the name of the third-party provider (`'bitbucket'`, `'dropbox'`, `'facebook'`, `'foursquare'`, `'github'`, `'google'`, `'instagram'`, `'linkedin'`, `'live'`, `'twitter'`, `'vk'`, `'arcgisonline'`, `'yahoo'`, `'phabricator'`)
   or an object containing a custom provider with the following:
     - `protocol` - the authorization protocol used. Must be one of:
         - `'oauth'` - OAuth 1.0a
@@ -113,7 +113,7 @@ Each strategy accepts the following optional settings:
   as required by your application. Consult the provider for their specific supported scopes.
 - `config` - a configuration object used to customize the provider settings. The built-in `'twitter'` provider accepts the `extendedProfile`
   option which allows disabling the extra profile request when the provider returns the user information in the callback (defaults to `true`).
-  The built-in `'github'` provider accepts the `uri` option which allows pointing to a private enterprise installation
+  The built-in `'github'` and `'phabricator'` providers accept the `uri` option which allows pointing to a private enterprise installation
   (e.g. `'https://vpn.example.com'`).
 - `profileParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,11 @@ internals.implementation = function (server, options) {
         settings.provider = Providers[settings.provider].call(null, settings.config);
     }
 
-    Joi.assert(settings, internals.schema);
+    var results = Joi.validate(settings, internals.schema);
+    Hoek.assert(!results.error, results.error);
+
+    // Passed validation, use Joi converted settings
+    settings = results.value;
 
     // Setup cookie for managing temporary authorization state
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,11 +71,7 @@ internals.implementation = function (server, options) {
         settings.provider = Providers[settings.provider].call(null, settings.config);
     }
 
-    var results = Joi.validate(settings, internals.schema);
-    Hoek.assert(!results.error, results.error);
-
-    // Passed validation, use Joi converted settings
-    settings = results.value;
+    Joi.assert(settings, internals.schema);
 
     // Setup cookie for managing temporary authorization state
 

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -19,5 +19,6 @@ exports = module.exports = {
     twitter: require('./twitter'),
     vk: require('./vk'),
     yahoo: require('./yahoo'),
-    arcgisonline: require('./arcgisonline')
+    arcgisonline: require('./arcgisonline'),
+    phabricator: require('./phabricator')
 };

--- a/lib/providers/phabricator.js
+++ b/lib/providers/phabricator.js
@@ -35,7 +35,7 @@ exports = module.exports = function (options) {
                     username: profile.result.userName,
                     displayName: profile.result.realName,
                     email: profile.result.primaryEmail,
-                    raw: profile.result
+                    raw: profile
                 };
 
                 return callback();

--- a/lib/providers/phabricator.js
+++ b/lib/providers/phabricator.js
@@ -1,0 +1,45 @@
+// Load modules
+var Joi = require('joi');
+var Hoek = require('hoek');
+
+// Declare internals
+
+var internals = {};
+
+internals.schema = Joi.object({
+    uri: Joi.string().uri().required()
+}).required();
+
+exports = module.exports = function (options) {
+
+    var results = Joi.validate(options, internals.schema);
+
+    Hoek.assert(!results.error, results.error);
+
+    var settings = results.value;
+
+    return {
+        protocol: 'oauth2',
+        auth: settings.uri + '/oauthserver/auth/',
+        token: settings.uri + '/oauthserver/token/',
+        scope: ['whoami'],
+        scopeSeparator: ',',
+        profile: function (credentials, params, get, callback) {
+            var query = {
+                access_token: credentials.token
+            };
+
+            get(settings.uri + '/api/user.whoami', query, function (profile) {
+                credentials.profile = {
+                    id: profile.result.phid,
+                    username: profile.result.userName,
+                    displayName: profile.result.realName,
+                    email: profile.result.primaryEmail,
+                    raw: profile.result
+                };
+
+                return callback();
+            });
+        }
+    };
+};

--- a/test/providers.js
+++ b/test/providers.js
@@ -1689,4 +1689,104 @@ describe('#linkedin', function () {
             });
         });
     });
+
+    describe('#phabricator', function () {
+
+        it('fails with no uri', { parallel: false }, function (done) {
+
+            var mock = new Mock.V2();
+            mock.start(function (provider) {
+
+                var server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, function (err) {
+
+                    expect(err).to.not.exist();
+
+                    expect( function() {
+                        Bell.providers.phabricator();
+                    }).to.throw(Error);
+
+                    Mock.clear();
+                    mock.stop(done);
+                });
+            });
+        });
+
+        it('authenticates with mock and custom uri', { parallel: false }, function (done) {
+
+            var mock = new Mock.V2();
+            mock.start(function (provider) {
+
+                var server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, function (err) {
+
+                    expect(err).to.not.exist();
+
+                    var custom = Bell.providers.phabricator({ uri: 'http://example.com' });
+                    Hoek.merge(custom, provider);
+
+                    var profile = {
+                        result: {
+                            phid: '1234567890',
+                            userName: 'steve',
+                            realName: 'steve',
+                            primaryEmail: 'steve@example.com'
+                        }
+                    };
+
+                    Mock.override('http://example.com/api/user.whoami', profile);
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: false,
+                        clientId: 'phabricator',
+                        clientSecret: 'secret',
+                        provider: custom
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: function (request, reply) {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', function (res) {
+
+                        var cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                        mock.server.inject(res.headers.location, function (res) {
+
+                            server.inject({ url: res.headers.location, headers: { cookie: cookie } }, function (res) {
+
+                                expect(res.result).to.deep.equal({
+                                    provider: 'custom',
+                                    token: '456',
+                                    expiresIn: 3600,
+                                    refreshToken: undefined,
+                                    query: {},
+                                    profile: {
+                                        id: '1234567890',
+                                        username: 'steve',
+                                        displayName: 'steve',
+                                        email: 'steve@example.com',
+                                        raw: profile
+                                    }
+                                });
+
+                                Mock.clear();
+                                mock.stop(done);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Added support for third party installations of phabricator, the user must supply a URI in the config options in order for it to work.

Closes #75 