### PR TITLE
update facebook URLs to use facebook Graph v2.3

### DIFF
--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -12,7 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        auth: 'https://graph.facebook.com/oauth/authorize',
+        auth: 'https://www.facebook.com/v2.3/dialog/oauth',
         token: 'https://graph.facebook.com/oauth/access_token',
         scope: ['email'],
         scopeSeparator: ',',
@@ -22,7 +22,7 @@ exports = module.exports = function (options) {
                 appsecret_proof: Crypto.createHmac('sha256', this.clientSecret).update(credentials.token).digest('hex')
             };
 
-            get('https://graph.facebook.com/me', query, function (profile) {
+            get('https://graph.facebook.com/v2.3/me', query, function (profile) {
 
                 credentials.profile = {
                     id: profile.id,

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -847,7 +847,7 @@ describe('Bell', function () {
                     var custom = Bell.providers.facebook();
                     Hoek.merge(custom, provider);
 
-                    Mock.override('https://graph.facebook.com/me', null);
+                    Mock.override('https://graph.facebook.com/v2.3/me', null);
 
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',
@@ -901,7 +901,7 @@ describe('Bell', function () {
                     var custom = Bell.providers.facebook();
                     Hoek.merge(custom, provider);
 
-                    Mock.override('https://graph.facebook.com/me', Boom.badRequest());
+                    Mock.override('https://graph.facebook.com/v2.3/me', Boom.badRequest());
 
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',
@@ -955,7 +955,7 @@ describe('Bell', function () {
                     var custom = Bell.providers.facebook();
                     Hoek.merge(custom, provider);
 
-                    Mock.override('https://graph.facebook.com/me', '{c');
+                    Mock.override('https://graph.facebook.com/v2.3/me', '{c');
 
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',
@@ -1051,9 +1051,9 @@ describe('Bell', function () {
                     var custom = Bell.providers.facebook();
                     Hoek.merge(custom, provider);
 
-                    Mock.override('https://graph.facebook.com/me', function (uri) {
+                    Mock.override('https://graph.facebook.com/v2.3/me', function (uri) {
 
-                        expect(uri).to.equal('https://graph.facebook.com/me?appsecret_proof=d32b1d35fd115c4a496e06fd8df67eed8057688b17140a2cef365cb235817102');
+                        expect(uri).to.equal('https://graph.facebook.com/v2.3/me?appsecret_proof=d32b1d35fd115c4a496e06fd8df67eed8057688b17140a2cef365cb235817102');
                         Mock.clear();
                         mock.stop(done);
                     });
@@ -1104,8 +1104,8 @@ describe('Bell', function () {
                     var custom = Bell.providers.facebook();
                     Hoek.merge(custom, provider);
 
-                    Mock.override('https://graph.facebook.com/me', function (uri) {
-                        expect(uri).to.equal('https://graph.facebook.com/me?appsecret_proof=d32b1d35fd115c4a496e06fd8df67eed8057688b17140a2cef365cb235817102&fields=id%2Cemail%2Cpicture%2Cname%2Cfirst_name%2Cmiddle_name%2Clast_name%2Clink%2Clocale%2Ctimezone%2Cupdated_time%2Cverified%2Cgender');
+                    Mock.override('https://graph.facebook.com/v2.3/me', function (uri) {
+                        expect(uri).to.equal('https://graph.facebook.com/v2.3/me?appsecret_proof=d32b1d35fd115c4a496e06fd8df67eed8057688b17140a2cef365cb235817102&fields=id%2Cemail%2Cpicture%2Cname%2Cfirst_name%2Cmiddle_name%2Clast_name%2Clink%2Clocale%2Ctimezone%2Cupdated_time%2Cverified%2Cgender');
                         Mock.clear();
                         mock.stop(done);
                     });

--- a/test/providers.js
+++ b/test/providers.js
@@ -48,7 +48,7 @@ describe('Bell', function () {
                         email: 'steve@example.com'
                     };
 
-                    Mock.override('https://graph.facebook.com/me', profile);
+                    Mock.override('https://graph.facebook.com/v2.3/me', profile);
 
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',


### PR DESCRIPTION
might be a fix for #66 

reference:
- https://developers.facebook.com/docs/apps/upgrading
- https://github.com/jaredhanson/passport-facebook/commit/c5a3fa65685eae74de2b68564da7f3c6c440111c