### PR TITLE
add location setting similar to old hapi server location

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The `server.auth.strategy()` method requires the following strategy options:
 - `clientId` - the OAuth client identifier (consumer key).
 - `clientSecret` - the OAuth client secret (consumer secret).
 - `forceHttps` - A boolean indicating whether or not you want the redirect_uri to be forced to https. Useful if your hapi application runs as http, but is accessed through https.
+- `location` - Set the redirect_uri manually if it cannot be inferred properly from server settings.  Useful to override port, protocol, and host if proxied or forwarded.
 
 Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to `'bell-provider'` where 'provider' is the provider name

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `server.auth.strategy()` method requires the following strategy options:
 - `clientId` - the OAuth client identifier (consumer key).
 - `clientSecret` - the OAuth client secret (consumer secret).
 - `forceHttps` - A boolean indicating whether or not you want the redirect_uri to be forced to https. Useful if your hapi application runs as http, but is accessed through https.
-- `location` - Set the redirect_uri manually if it cannot be inferred properly from server settings.  Useful to override port, protocol, and host if proxied or forwarded.
+- `location` - Set the base redirect_uri manually if it cannot be inferred properly from server settings. Useful to override port, protocol, and host if proxied or forwarded.
 
 Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to `'bell-provider'` where 'provider' is the provider name

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,8 @@ internals.schema = Joi.object({
     name: Joi.string().required(),
     config: Joi.object(),
     profileParams: Joi.object(),
-    forceHttps: Joi.boolean().optional().default(false)
+    forceHttps: Joi.boolean().optional().default(false),
+    location: Joi.string().optional().default(false)
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -149,7 +149,7 @@ exports.v2 = function (settings) {
             }
             query.client_id = settings.clientId;
             query.response_type = 'code';
-            query.redirect_uri = internals.location(request, protocol);
+            query.redirect_uri = internals.location(request, protocol, settings.location);
             query.state = nonce;
 
             var scope = settings.scope || settings.provider.scope;
@@ -189,7 +189,7 @@ exports.v2 = function (settings) {
             client_secret: settings.clientSecret,
             grant_type: 'authorization_code',
             code: request.query.code,
-            redirect_uri: internals.location(request, protocol)
+            redirect_uri: internals.location(request, protocol, settings.location)
         };
 
         var requestOptions = {
@@ -498,8 +498,11 @@ internals.parse = function (payload) {
 };
 
 
-internals.location = function (request, protocol) {
+internals.location = function (request, protocol, location) {
 
+    if (location) {
+        return location + request.path;
+    }
     var info = request.connection.info;
     protocol = protocol || info.protocol;
     var host = request.info.host || (info.host + ':' + info.port);


### PR DESCRIPTION
The `forceHttps` option is not sufficient to cover every configuration.  For example the port visible to the user's browser may be different than the port inferred by the Hapi server.  In fact, the host may also be different if there is a load balancer involved.  This PR attempts to restore the flexibility available when bell referenced the Hapi server location setting.