### PR TITLE
OAuth client resource() endpoint

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -304,34 +304,45 @@ internals.Client.prototype.temporary = function (oauth_callback, callback) {
 };
 
 
-internals.Client.prototype.token = function (oauth_token, oauth_verifier, tokenSecret, callback) {
+internals.Client.prototype.token = function (oauthToken, oauthVerifier, tokenSecret, callback) {
 
     // Token Credentials (2.3)
 
     var oauth = {
-        oauth_token: oauth_token,
-        oauth_verifier: oauth_verifier
+        oauth_token: oauthToken,
+        oauth_verifier: oauthVerifier
     };
 
     this.request('post', this.settings.token, null, oauth, tokenSecret, 'token credentials', callback);
 };
 
 
-internals.Client.prototype.get = function (uri, params, oauth_token, tokenSecret, callback) {
+internals.Client.prototype.get = function (uri, params, oauthToken, tokenSecret, callback) {
+
+    this.resource('get', uri, params, { token: oauthToken, secret: tokenSecret }, callback);
+};
+
+
+internals.Client.prototype.resource = function (method, uri, params, options, callback) {
 
     // Making Requests (3.1)
 
     var oauth = {
-        oauth_token: oauth_token
+        oauth_token: options.token
     };
 
-    this.request('get', uri, params, oauth, tokenSecret, 'token credentials', callback);
+    if (!options.stream) {
+        return this.request(method, uri, params, oauth, options.secret, 'resource', callback);
+    }
+
+    this._prepare(method, uri, params, oauth, options, function (method, uri, header) {
+
+        Wreck.request(method, uri, { headers: { Authorization: header } }, callback);
+    });
 };
 
 
-internals.Client.prototype.request = function (method, uri, params, oauth, tokenSecret, type, callback) {
-
-    var provider = this.provider;
+internals.Client.prototype._prepare = function (method, uri, params, oauth, options, next) {
 
     if (this.settings.version) {
         oauth.oauth_version = this.settings.version;
@@ -341,23 +352,34 @@ internals.Client.prototype.request = function (method, uri, params, oauth, token
     oauth.oauth_timestamp = Math.floor(Date.now() / 1000).toString();
     oauth.oauth_consumer_key = this.settings.clientId;
     oauth.oauth_signature_method = 'HMAC-SHA1';
-    oauth.oauth_signature = this.signature(method, uri, params, oauth, tokenSecret);
+    oauth.oauth_signature = this.signature(method, uri, params, oauth, options.secret);
 
     var query = params ? ('?' + Querystring.encode(params)) : '';
-    Wreck[method](uri + query, { headers: { Authorization: internals.Client.header(oauth) } }, function (err, res, payload) {
+    return next(method, uri + query, internals.Client.header(oauth));
+};
 
-        if (err ||
-            res.statusCode !== 200) {
 
-            return callback(Boom.internal('Failed obtaining ' + provider + ' ' + type, err || payload));
-        }
+internals.Client.prototype.request = function (method, uri, params, oauth, tokenSecret, type, callback) {
 
-        payload = internals.parse(payload);
-        if (payload instanceof Error) {
-            return callback(Boom.internal('Received invalid payload from ' + provider + ' ' + type + ' endpoint', payload));
-        }
+    var desc = this.provider + ' ' + type;
 
-        return callback(null, payload);
+    this._prepare(method, uri, params, oauth, { secret: tokenSecret }, function (method, uri, header) {
+
+        Wreck[method](uri, { headers: { Authorization: header } }, function (err, res, payload) {
+
+            if (err ||
+                res.statusCode !== 200) {
+
+                return callback(Boom.internal('Failed obtaining ' + desc, err || payload));
+            }
+
+            payload = internals.parse(payload);
+            if (payload instanceof Error) {
+                return callback(Boom.internal('Received invalid payload from ' + desc + ' endpoint', payload));
+            }
+
+            return callback(null, payload);
+        });
     });
 };
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -365,7 +365,7 @@ internals.Client.prototype.request = function (method, uri, params, oauth, token
 
     this._prepare(method, uri, params, oauth, { secret: tokenSecret }, function (method, uri, header) {
 
-        Wreck[method](uri, { headers: { Authorization: header } }, function (err, res, payload) {
+        Wreck[method.toLowerCase()](uri, { headers: { Authorization: header } }, function (err, res, payload) {
 
             if (err ||
                 res.statusCode !== 200) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bell",
   "description": "Third-party login plugin for hapi",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "repository": "git://github.com/hapijs/bell",
   "main": "lib/index.js",
   "keywords": [

--- a/test/mock.js
+++ b/test/mock.js
@@ -57,7 +57,7 @@ exports.V1 = internals.V1 = function (fail) {
                         oauth_callback_confirmed: true
                     };
 
-                    reply(Querystring.encode(payload)).type('application/x-www-form-urlencoded');
+                    return reply(Querystring.encode(payload)).type('application/x-www-form-urlencoded');
                 }
             }
         },
@@ -75,7 +75,7 @@ exports.V1 = internals.V1 = function (fail) {
                     token.verifier = '123';
 
                     var extra = Object.keys(request.query).length > 1 ? '&extra=true' : '';
-                    reply().redirect(unescape(token.callback) + '?oauth_token=' + request.query.oauth_token + '&oauth_verifier=' + token.verifier + extra);
+                    return reply().redirect(unescape(token.callback) + '?oauth_token=' + request.query.oauth_token + '&oauth_verifier=' + token.verifier + extra);
                 }
             }
         },
@@ -106,7 +106,21 @@ exports.V1 = internals.V1 = function (fail) {
                         payload.screen_name = 'Steve Stevens';
                     }
 
-                    reply(Querystring.encode(payload)).type('application/x-www-form-urlencoded');
+                    return reply(Querystring.encode(payload)).type('application/x-www-form-urlencoded');
+                }
+            }
+        },
+        {
+            method: '*',
+            path: '/resource',
+            config: {
+                bind: this,
+                handler: function (request, reply) {
+
+                    var header = Hawk.utils.parseAuthorizationHeader(request.headers.authorization.replace(/OAuth/i, 'Hawk'), ['realm', 'oauth_consumer_key', 'oauth_token', 'oauth_signature_method', 'oauth_verifier', 'oauth_signature', 'oauth_version', 'oauth_timestamp', 'oauth_nonce']);
+                    expect(header.oauth_token).to.equal('final');
+
+                    return reply('some text reply');
                 }
             }
         }


### PR DESCRIPTION
Closes #90 

This is a bit convoluted but required to keep it backwards compatible with minimal code repeats. In future breaking versions it will be worth getting rid of the `request()` and `get()` methods and just keep the new `resource()` one.