### PR TITLE
Updating Readme examples to work with current version of hapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ combine **bell** with the [**hapi-auth-cookie**](https://github.com/hapijs/hapi-
 
 ```javascript
 var Hapi = require('hapi');
-var server = new Hapi.Server(8000);
+var server = new Hapi.Server();
+
+server.connection({ port: 8000 });
 
 // Register bell with the server
 server.register(require('bell'), function (err) {
@@ -145,7 +147,9 @@ To keep track of the token expiry time, `request.auth.credentials.expiresIn` pro
 
 ```javascript
 var Hapi = require('hapi');
-var server = new Hapi.Server(8000);
+var server = new Hapi.Server();
+
+server.connection({ port: 8000 });
 
 // Register bell with the server
 server.register(require('bell'), function (err) {


### PR DESCRIPTION
Removing port in the constructor and adding call to connection.