### PR TITLE
Ensure only 1 authentication method is used during /token access in o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The `server.auth.strategy()` method requires the following strategy options:
         - `'oauth'` - OAuth 1.0a
         - `'oauth2'` - OAuth 2.0
     - `temporary` - the temporary credentials (request token) endpoint (OAuth 1.0a only).
-    - `useParamsAuth` - boolean that determines if OAuth client id and client secret will be sent as parameters as opposed to an Authorization header (OAuth 2.0 only). Defaults to false.
+    - `useParamsAuth` - boolean that determines if OAuth client id and client secret will be sent as parameters as opposed to an Authorization header (OAuth 2.0 only). Defaults to `false`.
     - `auth` - the authorization endpoint URI.
     - `token` - the access token endpoint URI.
     - `version` - the OAuth version.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The `server.auth.strategy()` method requires the following strategy options:
         - `'oauth'` - OAuth 1.0a
         - `'oauth2'` - OAuth 2.0
     - `temporary` - the temporary credentials (request token) endpoint (OAuth 1.0a only).
+    - `useParamsAuth` - boolean that determines if OAuth client id and client secret will be sent as parameters as opposed to an Authorization header (OAuth 2.0 only). Defaults to false.
     - `auth` - the authorization endpoint URI.
     - `token` - the access token endpoint URI.
     - `version` - the OAuth version.

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ internals.schema = Joi.object({
         protocol: Joi.string().valid('oauth', 'oauth2'),
         temporary: Joi.string().when('protocol', { is: 'oauth', then: Joi.required(), otherwise: Joi.forbidden() }),
         auth: Joi.string().required(),
-        authMethod: Joi.string().valid('basic', 'param').when('protocol', { is: 'oauth2', then: Joi.required(), otherwize: Joi.forbidden() }),
+        authMethod: Joi.string().valid('basic', 'param').when('protocol', { is: 'oauth2', then: Joi.required(), otherwise: Joi.forbidden() }),
         token: Joi.string().required(),
         headers: Joi.object(),
         profile: Joi.func(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ internals.schema = Joi.object({
         protocol: Joi.string().valid('oauth', 'oauth2'),
         temporary: Joi.string().when('protocol', { is: 'oauth', then: Joi.required(), otherwise: Joi.forbidden() }),
         auth: Joi.string().required(),
+        authMethod: Joi.string().valid('basic', 'param').when('protocol', { is: 'oauth2', then: Joi.required(), otherwize: Joi.forbidden() }),
         token: Joi.string().required(),
         headers: Joi.object(),
         profile: Joi.func(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ internals.schema = Joi.object({
         protocol: Joi.string().valid('oauth', 'oauth2'),
         temporary: Joi.string().when('protocol', { is: 'oauth', then: Joi.required(), otherwise: Joi.forbidden() }),
         auth: Joi.string().required(),
-        authMethod: Joi.string().valid('basic', 'param').when('protocol', { is: 'oauth2', then: Joi.required(), otherwise: Joi.forbidden() }),
+        useParamsAuth: Joi.boolean().default(false).when('protocol', { is: 'oauth2', then: Joi.optional(), otherwise: Joi.forbidden() }),
         token: Joi.string().required(),
         headers: Joi.object(),
         profile: Joi.func(),

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -189,20 +189,26 @@ exports.v2 = function (settings) {
         }
 
         query = {
-            client_id: settings.clientId,
-            client_secret: settings.clientSecret,
             grant_type: 'authorization_code',
             code: request.query.code,
             redirect_uri: internals.location(request, protocol, settings.location)
         };
 
+        if (settings.provider.authMethod === 'param') {
+            query.client_id = settings.clientId;
+            query.client_secret = settings.client_secret;
+        }
+
         var requestOptions = {
             payload: internals.queryString(query),
             headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'Authorization': 'Basic ' + (new Buffer(settings.clientId + ':' + settings.clientSecret, 'utf8')).toString('base64')
+                'Content-Type': 'application/x-www-form-urlencoded'
             }
         };
+
+        if (settings.provider.authMethod === 'basic') {
+            requestOptions.headers.Authorization = 'Basic ' + (new Buffer(settings.clientId + ':' + settings.clientSecret, 'utf8')).toString('base64');
+        }
 
         if (settings.provider.headers) {
             Hoek.merge(requestOptions.headers, settings.provider.headers);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -194,7 +194,7 @@ exports.v2 = function (settings) {
             redirect_uri: internals.location(request, protocol, settings.location)
         };
 
-        if (settings.provider.authMethod === 'param') {
+        if (settings.provider.useParamsAuth) {
             query.client_id = settings.clientId;
             query.client_secret = settings.client_secret;
         }
@@ -206,7 +206,7 @@ exports.v2 = function (settings) {
             }
         };
 
-        if (settings.provider.authMethod === 'basic') {
+        if (!settings.provider.useParamsAuth) {
             requestOptions.headers.Authorization = 'Basic ' + (new Buffer(settings.clientId + ':' + settings.clientSecret, 'utf8')).toString('base64');
         }
 

--- a/lib/providers/arcgisonline.js
+++ b/lib/providers/arcgisonline.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://www.arcgis.com/sharing/rest/oauth2/authorize',
         token: 'https://www.arcgis.com/sharing/rest/oauth2/token',
         scope: [],

--- a/lib/providers/arcgisonline.js
+++ b/lib/providers/arcgisonline.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://www.arcgis.com/sharing/rest/oauth2/authorize',
         token: 'https://www.arcgis.com/sharing/rest/oauth2/token',
         scope: [],

--- a/lib/providers/dropbox.js
+++ b/lib/providers/dropbox.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://www.dropbox.com/1/oauth2/authorize',
         token: 'https://api.dropbox.com/1/oauth2/token',
         profile: function (credentials, params, get, callback) {

--- a/lib/providers/dropbox.js
+++ b/lib/providers/dropbox.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://www.dropbox.com/1/oauth2/authorize',
         token: 'https://api.dropbox.com/1/oauth2/token',
         profile: function (credentials, params, get, callback) {

--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -12,7 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://www.facebook.com/v2.3/dialog/oauth',
         token: 'https://graph.facebook.com/oauth/access_token',
         scope: ['email'],

--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -12,6 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://www.facebook.com/v2.3/dialog/oauth',
         token: 'https://graph.facebook.com/oauth/access_token',
         scope: ['email'],

--- a/lib/providers/foursquare.js
+++ b/lib/providers/foursquare.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://foursquare.com/oauth2/authenticate',
         token: 'https://foursquare.com/oauth2/access_token',
         profile: function (credentials, params, get, callback) {

--- a/lib/providers/foursquare.js
+++ b/lib/providers/foursquare.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://foursquare.com/oauth2/authenticate',
         token: 'https://foursquare.com/oauth2/access_token',
         profile: function (credentials, params, get, callback) {

--- a/lib/providers/github.js
+++ b/lib/providers/github.js
@@ -15,6 +15,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: uri + '/login/oauth/authorize',
         token: uri + '/login/oauth/access_token',
         scope: ['user:email'],

--- a/lib/providers/github.js
+++ b/lib/providers/github.js
@@ -15,7 +15,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: uri + '/login/oauth/authorize',
         token: uri + '/login/oauth/access_token',
         scope: ['user:email'],

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://accounts.google.com/o/oauth2/auth',
         token: 'https://accounts.google.com/o/oauth2/token',
         scope: ['openid', 'email'],

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://accounts.google.com/o/oauth2/auth',
         token: 'https://accounts.google.com/o/oauth2/token',
         scope: ['openid', 'email'],

--- a/lib/providers/instagram.js
+++ b/lib/providers/instagram.js
@@ -12,7 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://api.instagram.com/oauth/authorize',
         token: 'https://api.instagram.com/oauth/access_token',
         scope: ['basic'],

--- a/lib/providers/instagram.js
+++ b/lib/providers/instagram.js
@@ -12,6 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://api.instagram.com/oauth/authorize',
         token: 'https://api.instagram.com/oauth/access_token',
         scope: ['basic'],

--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -11,6 +11,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://www.linkedin.com/uas/oauth2/authorization',
         token: 'https://www.linkedin.com/uas/oauth2/accessToken',
         scope: ['r_fullprofile', 'r_emailaddress', 'r_contactinfo'],

--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -11,7 +11,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://www.linkedin.com/uas/oauth2/authorization',
         token: 'https://www.linkedin.com/uas/oauth2/accessToken',
         scope: ['r_fullprofile', 'r_emailaddress', 'r_contactinfo'],

--- a/lib/providers/live.js
+++ b/lib/providers/live.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://login.live.com/oauth20_authorize.srf',
         token: 'https://login.live.com/oauth20_token.srf',
         scope: ['wl.basic', 'wl.emails'],

--- a/lib/providers/live.js
+++ b/lib/providers/live.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://login.live.com/oauth20_authorize.srf',
         token: 'https://login.live.com/oauth20_token.srf',
         scope: ['wl.basic', 'wl.emails'],

--- a/lib/providers/nest.js
+++ b/lib/providers/nest.js
@@ -12,7 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://home.nest.com/login/oauth2',
         token: 'https://api.home.nest.com/oauth2/access_token'
     };

--- a/lib/providers/nest.js
+++ b/lib/providers/nest.js
@@ -12,6 +12,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://home.nest.com/login/oauth2',
         token: 'https://api.home.nest.com/oauth2/access_token'
     };

--- a/lib/providers/phabricator.js
+++ b/lib/providers/phabricator.js
@@ -20,7 +20,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: settings.uri + '/oauthserver/auth/',
         token: settings.uri + '/oauthserver/token/',
         scope: ['whoami'],

--- a/lib/providers/phabricator.js
+++ b/lib/providers/phabricator.js
@@ -20,6 +20,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: settings.uri + '/oauthserver/auth/',
         token: settings.uri + '/oauthserver/token/',
         scope: ['whoami'],

--- a/lib/providers/reddit.js
+++ b/lib/providers/reddit.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'basic',
+        useParamsAuth: false,
         auth: 'https://www.reddit.com/api/v1/authorize',
         token: 'https://www.reddit.com/api/v1/access_token',
         scope: ['identity'], // minimal scope to request

--- a/lib/providers/reddit.js
+++ b/lib/providers/reddit.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'basic',
         auth: 'https://www.reddit.com/api/v1/authorize',
         token: 'https://www.reddit.com/api/v1/access_token',
         scope: ['identity'], // minimal scope to request

--- a/lib/providers/vk.js
+++ b/lib/providers/vk.js
@@ -10,6 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
+        authMethod: 'param',
         auth: 'https://oauth.vk.com/authorize',
         token: 'https://oauth.vk.com/access_token',
         profile: function (credentials, params, get, callback) {

--- a/lib/providers/vk.js
+++ b/lib/providers/vk.js
@@ -10,7 +10,7 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        authMethod: 'param',
+        useParamsAuth: true,
         auth: 'https://oauth.vk.com/authorize',
         token: 'https://oauth.vk.com/access_token',
         profile: function (credentials, params, get, callback) {

--- a/test/index.js
+++ b/test/index.js
@@ -171,7 +171,7 @@ describe('Bell', function () {
 
     it('authenticates an endpoint via oauth2 and basic authentication', function (done) {
 
-        var mock = new Mock.V2('basic');
+        var mock = new Mock.V2(false);
         mock.start(function (provider) {
 
             var server = new Hapi.Server();

--- a/test/mock.js
+++ b/test/mock.js
@@ -154,10 +154,14 @@ internals.V1.prototype.stop = function (callback) {
 };
 
 
-exports.V2 = internals.V2 = function (authMethod) {
+exports.V2 = internals.V2 = function (useParamsAuth) {
 
     this.codes = {};
-    this.authMethod = authMethod ? authMethod : 'param';
+
+    if (typeof useParamsAuth === 'undefined') {
+        useParamsAuth = true;
+    }
+    this.useParamsAuth = useParamsAuth;
 
     this.server = new Hapi.Server();
     this.server.connection({ host: 'localhost' });
@@ -189,12 +193,14 @@ exports.V2 = internals.V2 = function (authMethod) {
                     var code = this.codes[request.payload.code];
                     expect(code).to.exist();
                     expect(code.redirect_uri).to.equal(request.payload.redirect_uri);
-                    if (authMethod === 'param') {
+                    if (useParamsAuth) {
                         expect(code.client_id).to.equal(request.payload.client_id);
+                        expect(request.headers.authorization).to.be.undefined();
                     }
-                    else if (authMethod === 'basic') {
+                    else {
                         var basic = new Buffer(request.headers.authorization.slice(6), 'base64').toString();
                         expect(basic).to.startWith(code.client_id);
+                        expect(request.payload.client_id).to.be.undefined();
                     }
 
                     var payload = {
@@ -236,7 +242,7 @@ internals.V2.prototype.start = function (callback) {
 
         return callback({
             protocol: 'oauth2',
-            authMethod: self.authMethod,
+            useParamsAuth: self.useParamsAuth,
             auth: self.server.info.uri + '/auth',
             token: self.server.info.uri + '/token'
         });

--- a/test/providers.js
+++ b/test/providers.js
@@ -1075,7 +1075,7 @@ describe('Bell', function () {
 
         it('authenticates with mock', { parallel: false }, function (done) {
 
-            var mock = new Mock.V1();
+            var mock = new Mock.V2();
             mock.start(function (provider) {
 
                 var server = new Hapi.Server();
@@ -1137,7 +1137,7 @@ describe('Bell', function () {
 
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
-                                    token: 'final',
+                                    token: '456',
                                     expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
@@ -1165,7 +1165,7 @@ describe('Bell', function () {
 
         it('authenticates with mock when user has no email set', { parallel: false }, function (done) {
 
-            var mock = new Mock.V1();
+            var mock = new Mock.V2();
             mock.start(function (provider) {
 
                 var server = new Hapi.Server();
@@ -1228,7 +1228,7 @@ describe('Bell', function () {
 
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
-                                    token: 'final',
+                                    token: '456',
                                     expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},


### PR DESCRIPTION
…auth2

Added authMethod in provider options schema which is required when oauth2 is selected.

Now, when retrieving the token bell will either use body parameters or basic header auth but not both at the same time. See Issue #98 .

I have updated all the oauth2 providers as per their specs:

[arcgisonline](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r30000009z000000)
[dropbox](https://www.dropbox.com/developers/core/docs#oauth2-methods)
[facebook](https://developers.facebook.com/docs/facebook-login/access-tokens#apptokens)
[foursquare](https://developer.foursquare.com/overview/auth)
[github](https://developer.github.com/v3/oauth/)
[google](https://developers.google.com/identity/protocols/OpenIDConnect)
[instagram](https://instagram.com/developer/authentication/)
[linkedin](https://developer.linkedin.com/docs/oauth2)
[live](https://msdn.microsoft.com/en-us/library/hh243647.aspx)
[nest](https://developer.nest.com/documentation/cloud/how-to-auth)
[phabricator](https://secure.phabricator.com/book/phabcontrib/article/using_oauthserver/)
[reddit](https://github.com/reddit/reddit/wiki/OAuth2)
[vk](https://vk.com/dev/auth_sites)
