### PR TITLE
update the google oauth endpoint to use v2

### DIFF
--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -16,7 +16,7 @@ exports = module.exports = function (options) {
         scope: ['openid', 'email'],
         profile: function (credentials, params, get, callback) {
 
-            get('https://www.googleapis.com/oauth2/v1/userinfo', null, function (profile) {
+            get('https://www.googleapis.com/oauth2/v2/userinfo', null, function (profile) {
 
                 credentials.profile = {
                     id: profile.id,


### PR DESCRIPTION
I believe there is a v3 version but it is not yet documented, so the v2 version is what is current.