### PR TITLE
 Fix clientSecret usage and adds test case

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -196,7 +196,7 @@ exports.v2 = function (settings) {
 
         if (settings.provider.useParamsAuth) {
             query.client_id = settings.clientId;
-            query.client_secret = settings.client_secret;
+            query.client_secret = settings.clientSecret;
         }
 
         var requestOptions = {

--- a/test/mock.js
+++ b/test/mock.js
@@ -20,6 +20,7 @@ var internals = {};
 var lab = exports.lab = Lab.script();
 var expect = Code.expect;
 
+exports.SECRET_TESTER = internals.SECRET_TESTER = 'secretTester';
 
 exports.V1 = internals.V1 = function (fail) {
 
@@ -220,6 +221,10 @@ exports.V2 = internals.V2 = function (useParamsAuth) {
                     if (code.client_id === 'vk') {
                         payload.user_id = '1234567890';
                         payload.email = 'steve@example.com';
+                    }
+
+                    if (code.client_id === internals.SECRET_TESTER) {
+                        expect(internals.SECRET_TESTER).to.equal(request.payload.client_secret);
                     }
 
                     reply(payload);

--- a/test/mock.js
+++ b/test/mock.js
@@ -20,7 +20,8 @@ var internals = {};
 var lab = exports.lab = Lab.script();
 var expect = Code.expect;
 
-exports.SECRET_TESTER = internals.SECRET_TESTER = 'secretTester';
+exports.CLIENT_ID_TESTER = internals.CLIENT_ID_TESTER = 'clientIdTester';
+exports.CLIENT_SECRET_TESTER = internals.CLIENT_SECRET_TESTER = 'clientSecretTester';
 
 exports.V1 = internals.V1 = function (fail) {
 
@@ -223,8 +224,8 @@ exports.V2 = internals.V2 = function (useParamsAuth) {
                         payload.email = 'steve@example.com';
                     }
 
-                    if (code.client_id === internals.SECRET_TESTER) {
-                        expect(internals.SECRET_TESTER).to.equal(request.payload.client_secret);
+                    if (code.client_id === internals.CLIENT_ID_TESTER) {
+                        expect(internals.CLIENT_SECRET_TESTER).to.equal(request.payload.client_secret);
                     }
 
                     reply(payload);

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1128,8 +1128,8 @@ describe('Bell', function () {
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',
                         isSecure: false,
-                        clientId: Mock.SECRET_TESTER,
-                        clientSecret: Mock.SECRET_TESTER,
+                        clientId: Mock.CLIENT_ID_TESTER,
+                        clientSecret: Mock.CLIENT_SECRET_TESTER,
                         provider: provider
                     });
 

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1090,6 +1090,7 @@ describe('Bell', function () {
                         config: {
                             auth: 'custom',
                             handler: function (request, reply) {
+
                                 reply(request.auth.credentials);
                             }
                         }
@@ -1099,7 +1100,9 @@ describe('Bell', function () {
                         var cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
 
                         mock.server.inject(res.headers.location, function (res) {
+
                             server.inject({ url: res.headers.location, headers: { cookie: cookie } }, function (res) {
+
                                 expect(res.statusCode).to.equal(500);
                                 Mock.clear();
                                 mock.stop(done);
@@ -1135,6 +1138,7 @@ describe('Bell', function () {
                         config: {
                             auth: 'custom',
                             handler: function (request, reply) {
+
                                 reply(request.auth.credentials);
                             }
                         }

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1097,6 +1097,7 @@ describe('Bell', function () {
                     });
 
                     server.inject('/login', function (res) {
+
                         var cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
 
                         mock.server.inject(res.headers.location, function (res) {


### PR DESCRIPTION
This duplicate the fix from [#101](https://github.com/hapijs/bell/pull/101) and includes a proposed test case that would fail without the fix.

The previous suite of tests would complain if the user leaves off the clientSecret or gives it a value of undefined.  But this particular bug happened at the point the clientSecret was assign as part of the query and then converted into a queryString.  Since the wrong variable name was passed the query property client_secret was given a value of undefined.  Then the queryString conversion method changed the undefined value into an empty string which is valid for a clientSecret. 