### PR TITLE
Updated Google provider so that login uses the recommended Google+ People endpoint

### DIFF
--- a/examples/google.js
+++ b/examples/google.js
@@ -5,7 +5,7 @@ var Bell = require('../');
 
 
 var server = new Hapi.Server();
-server.connection({ port: 8000 });
+server.connection({ host: 'localhost', port: 4567});
 
 server.register(Bell, function (err) {
 
@@ -30,9 +30,14 @@ server.register(Bell, function (err) {
         method: '*',
         path: '/bell/door',
         config: {
-            auth: 'google',
+            auth: {
+                strategy: 'google',
+                mode: 'try'
+            },
             handler: function (request, reply) {
-
+                if (!request.auth.isAuthenticated) {
+                    return reply('Authentication failed due to: ' + request.auth.error.message);
+                }
                 reply('<pre>' + JSON.stringify(request.auth.credentials, null, 4) + '</pre>');
             }
         }

--- a/examples/google.js
+++ b/examples/google.js
@@ -35,6 +35,7 @@ server.register(Bell, function (err) {
                 mode: 'try'
             },
             handler: function (request, reply) {
+
                 if (!request.auth.isAuthenticated) {
                     return reply('Authentication failed due to: ' + request.auth.error.message);
                 }

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -13,7 +13,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: 'https://accounts.google.com/o/oauth2/v2/auth',
         token: 'https://www.googleapis.com/oauth2/v4/token',
-        scope: ['https://www.googleapis.com/auth/plus.login', 'https://www.googleapis.com/auth/plus.profile.emails.read'],
+        scope: ['profile', 'email'],
         profile: function (credentials, params, get, callback) {
 
             get('https://www.googleapis.com/plus/v1/people/me', null, function (profile) {

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -11,22 +11,18 @@ exports = module.exports = function (options) {
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: 'https://accounts.google.com/o/oauth2/auth',
-        token: 'https://accounts.google.com/o/oauth2/token',
-        scope: ['openid', 'email'],
+        auth: 'https://accounts.google.com/o/oauth2/v2/auth',
+        token: 'https://www.googleapis.com/oauth2/v4/token',
+        scope: ['https://www.googleapis.com/auth/plus.login', 'https://www.googleapis.com/auth/plus.profile.emails.read'],
         profile: function (credentials, params, get, callback) {
 
-            get('https://www.googleapis.com/oauth2/v1/userinfo', null, function (profile) {
+            get('https://www.googleapis.com/plus/v1/people/me', null, function (profile) {
 
                 credentials.profile = {
                     id: profile.id,
-                    username: profile.username,
-                    displayName: profile.name,
-                    name: {
-                        first: profile.given_name,
-                        last: profile.family_name
-                    },
-                    email: profile.email,
+                    displayName: profile.displayName,
+                    name: profile.name,
+                    emails: profile.emails,
                     raw: profile
                 };
 

--- a/test/providers.js
+++ b/test/providers.js
@@ -357,14 +357,21 @@ describe('Bell', function () {
 
                     var profile = {
                         id: '1234567890',
-                        username: 'steve',
-                        name: 'steve',
-                        given_name: 'steve',
-                        family_name: 'smith',
-                        email: 'steve@example.com'
+                        displayName: 'steve smith',
+                        name: {
+                            givenName: 'steve',
+                            familyName: 'smith'
+                        },
+                        emails: [
+                            {
+                              "type": "account",
+                              "value": "steve@example.com"
+                            }
+                        ],
+                        raw: profile
                     };
 
-                    Mock.override('https://www.googleapis.com/oauth2/v1/userinfo', profile);
+                    Mock.override('https://www.googleapis.com/plus/v1/people/me', profile);
 
                     server.auth.strategy('custom', 'bell', {
                         password: 'password',
@@ -401,13 +408,17 @@ describe('Bell', function () {
                                     query: {},
                                     profile: {
                                         id: '1234567890',
-                                        username: 'steve',
-                                        displayName: 'steve',
+                                        displayName: 'steve smith',
                                         name: {
-                                            first: 'steve',
-                                            last: 'smith'
+                                            givenName: 'steve',
+                                            familyName: 'smith'
                                         },
-                                        email: 'steve@example.com',
+                                        emails: [
+                                            {
+                                              "type": "account",
+                                              "value": "steve@example.com"
+                                            }
+                                        ],
                                         raw: profile
                                     }
                                 });

--- a/test/providers.js
+++ b/test/providers.js
@@ -364,8 +364,8 @@ describe('Bell', function () {
                         },
                         emails: [
                             {
-                              "type": "account",
-                              "value": "steve@example.com"
+                              'type': 'account',
+                              'value': 'steve@example.com'
                             }
                         ],
                         raw: profile
@@ -415,8 +415,8 @@ describe('Bell', function () {
                                         },
                                         emails: [
                                             {
-                                              "type": "account",
-                                              "value": "steve@example.com"
+                                              'type': 'account',
+                                              'value': 'steve@example.com'
                                             }
                                         ],
                                         raw: profile


### PR DESCRIPTION
Auth and Token have been updated based on values found in the OpenIDConnect discovery document:
    https://accounts.google.com/.well-known/openid-configuration
Scope discussion can be found here:
    https://developers.google.com/+/web/api/rest/oauth#plus.login
Goggle discovery doc for the plus service:
    https://www.googleapis.com/discovery/v1/apis/plus/v1/rest
Documentation of response body:
    https://developers.google.com/+/web/api/rest/latest/people#resource