### PR TITLE
Updated LinkedIn's default scope

### DIFF
--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -14,7 +14,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: 'https://www.linkedin.com/uas/oauth2/authorization',
         token: 'https://www.linkedin.com/uas/oauth2/accessToken',
-        scope: ['r_fullprofile', 'r_emailaddress', 'r_contactinfo'],
+        scope: ['r_basicprofile', 'r_emailaddress'],
         scopeSeparator: ',',
         profile: function (credentials, params, get, callback) {
 


### PR DESCRIPTION
Starting from May 12th, 2015, Linkedin's policy has changed: access to members' full profile and contact information has been restricted to Linkedin partners.

https://developer.linkedin.com/blog/posts/2015/developer-program-changes

To keep up to date with these recent changes, the default scope has been updated to information available to every application: users' basic profile and email address.

If one still wants to use the old scope (i.e. your application is part of Linkedin's partnership program), please configure the strategy's scope:

    server.auth.strategy('linkedin', 'bell', {
      provider: 'linkedin',
      password: '',
      clientId: '',
      clientSecret: '',
      scope: ['r_fullprofile', 'r_emailaddress', 'r_contactinfo']
    });

I believe that this is a *breaking change*, as the information retrieved by the application is not the same as before.
However, the LinkedIn provider previously didn't work at all, so I guess this is better than nothing!