### PR TITLE
Add provider credentialsHook function

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ The `server.auth.strategy()` method requires the following strategy options:
 - `clientSecret` - the OAuth client secret (consumer secret).
 - `forceHttps` - A boolean indicating whether or not you want the redirect_uri to be forced to https. Useful if your hapi application runs as http, but is accessed through https.
 - `location` - Set the base redirect_uri manually if it cannot be inferred properly from server settings. Useful to override port, protocol, and host if proxied or forwarded.
+- `credentialsHook` - a function used to manipulate credentials just before they're returned for authentication. The function signature is `function( request, name, credentials )` where:
+    - `request` - the current request object being processed
+    - `name` - the name of the current bell provider being used (twitter, facebook, etc..)
+    - `credentials` - the present credentials object that you can modify before it's returned
 
 Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to `'bell-provider'` where 'provider' is the provider name

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,8 @@ internals.schema = Joi.object({
     config: Joi.object(),
     profileParams: Joi.object(),
     forceHttps: Joi.boolean().optional().default(false),
-    location: Joi.string().optional().default(false)
+    location: Joi.string().optional().default(false),
+    credentialsHook: Joi.func().optional()
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -120,6 +120,7 @@ exports.v1 = function (settings) {
 
             settings.provider.profile.call(settings, credentials, payload, get, function () {
 
+                if ( settings.credentialsHook ) { credentials = settings.credentialsHook( request, name, credentials ); }
                 return reply.continue({ credentials: credentials });
             });
         });
@@ -279,6 +280,7 @@ exports.v2 = function (settings) {
 
             settings.provider.profile.call(settings, credentials, payload, get, function () {
 
+                if ( settings.credentialsHook ) { credentials = settings.credentialsHook( request, name, credentials ); }
                 return reply.continue({ credentials: credentials });
             });
         });


### PR DESCRIPTION
...to provider settings to allow for manipulation of credentials before returned from Bell.

I've built a hybrid authentication system for Hapi 9 that provides 'basic', 'token' (using JWT) and 'social' auth. If the user is already authenticated with basic or token and they hit a route handled by Bell, I check to see if that social account is associated with the authenticated user and if not, I make the association. If they're not authenticated and they hit that route and the account is associated, I have a flow that will then use those credentials to associate them. To make this possible, I had to slightly modify behavior of bell and I distilled that down to a simple hook that can be passed with options which provides for a way to analyze and manipulate the credentials object with the request and provider name available. This change should have zero impact on existing users and only affect users who implement the hook via options and then it's very powerful.