### PR TITLE
Fix wrong tests. OAuth1 does not include expiresIn for yahoo/bitbucke…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "boom": "2.x.x",
     "cryptiles": "2.x.x",
-    "hoek": "2.11.0",
+    "hoek": "2.x.x",
     "joi": "6.x.x",
     "wreck": "5.x.x"
   },
@@ -38,15 +38,15 @@
     "hapi": ">=8.x.x"
   },
   "devDependencies": {
-    "hapi": "8.x.x",
+    "hapi": "9.x.x",
     "hawk": "2.x.x",
     "lab": "5.x.x",
     "code": "1.x.x",
     "sinon": "1.x.x"
   },
   "scripts": {
-    "test": "node node_modules/lab/bin/lab -a code -t 100 -L",
-    "test-cov-html": "node node_modules/lab/bin/lab -a code -r html -o coverage.html"
+    "test": "node node_modules/lab/bin/lab -t 100 -L -v",
+    "test-cov-html": "node node_modules/lab/bin/lab -r html -o coverage.html"
   },
   "license": "BSD-3-Clause"
 }

--- a/test/providers.js
+++ b/test/providers.js
@@ -367,8 +367,7 @@ describe('Bell', function () {
                               'type': 'account',
                               'value': 'steve@example.com'
                             }
-                        ],
-                        raw: profile
+                        ]
                     };
 
                     Mock.override('https://www.googleapis.com/plus/v1/people/me', profile);
@@ -453,6 +452,7 @@ describe('Bell', function () {
                         id: '1234567890',
                         firstName: 'steve',
                         lastName: 'smith',
+                        email: 'steve.smith@domain.com',
                         headline: 'Master of the universe'
                     };
 
@@ -497,6 +497,7 @@ describe('Bell', function () {
                                             first: 'steve',
                                             last: 'smith'
                                         },
+                                        email: 'steve.smith@domain.com',
                                         headline: 'Master of the universe',
                                         raw: profile
                                     }
@@ -918,7 +919,6 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
-                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -984,7 +984,6 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
-                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1058,7 +1057,6 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
-                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1545,7 +1543,6 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
-                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {
@@ -1627,7 +1624,6 @@ describe('Bell', function () {
                                 expect(res.result).to.deep.equal({
                                     provider: 'custom',
                                     token: 'final',
-                                    expiresIn: 3600,
                                     secret: 'secret',
                                     query: {},
                                     profile: {


### PR DESCRIPTION
…t/twitter. Remove circular reference.

The tests were broken for a long time but upgraded dependencies and hoek > 2.11 uncovered those issues.