### PR TITLE
Meetup.com Provider

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -208,6 +208,21 @@ credentials.profile = {
 };
 ```
 
+### Meetup
+
+[Provider Documentation](http://www.meetup.com/meetup_api/auth)
+
+ - `scope`: Defaults to `['basic']`
+ - `config`: not applicable
+ - `auth`: https://secure.meetup.com/oauth2/authorize
+ - `token`: https://secure.meetup.com/oauth2/access
+
+The default profile response will look like this:
+
+```javascript
+// Defaults to meetup response (http://www.meetup.com/meetup_api/docs/2/member/#get)
+```
+
 ### Microsoft Live
 
 [Provider Documentation](https://msdn.microsoft.com/en-us/library/hh243647.aspx)

--- a/examples/meetup.js
+++ b/examples/meetup.js
@@ -1,0 +1,41 @@
+// Load modules
+
+var Hapi = require('hapi');
+var Bell = require('../');
+
+
+var server = new Hapi.Server();
+server.connection({ port: 8000 });
+
+server.register(Bell, function (err) {
+
+    server.auth.strategy('meetup', 'bell', {
+        provider: 'meetup',
+        password: 'cookie_encryption_password',
+        isSecure: false,
+        // Firstly give the meetup oauth docs a quick glance --> http://www.meetup.com/meetup_api/auth/#oauth2
+        // Secondly you'll need to create an OAuth consumer --> https://secure.meetup.com/meetup_api/oauth_consumers/
+        // Now you can fill in the required fields below and take this example for a test drive
+        clientId: '',
+        clientSecret: ''
+        // Uncomment the below line for more scopes, if not you get the "basic" scope by default
+        // scope: ['basic', 'ageless', 'group_edit', 'reporting']
+    });
+
+    server.route({
+        method: '*',
+        path: '/bell/door',
+        config: {
+            auth: 'meetup',
+            handler: function (request, reply) {
+
+                reply('<pre>' + JSON.stringify(request.auth.credentials, null, 4) + '</pre>');
+            }
+        }
+    });
+
+    server.start(function (err) {
+
+        console.log('Server started at:', server.info.uri);
+    });
+});

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -22,5 +22,6 @@ exports = module.exports = {
     yahoo: require('./yahoo'),
     arcgisonline: require('./arcgisonline'),
     phabricator: require('./phabricator'),
-    reddit: require('./reddit')
+    reddit: require('./reddit'),
+    meetup: require('./meetup')
 };

--- a/lib/providers/meetup.js
+++ b/lib/providers/meetup.js
@@ -1,0 +1,27 @@
+// Load modules
+
+
+// Declare internals
+
+var internals = {};
+
+
+exports = module.exports = function (options) {
+
+    return {
+        protocol: 'oauth2',
+        useParamsAuth: true,
+        auth: 'https://secure.meetup.com/oauth2/authorize',
+        token: 'https://secure.meetup.com/oauth2/access',
+        scope: ['basic'],
+        headers: { 'User-Agent': 'hapi-bell-meetup' },
+        profile: function (credentials, params, get, callback) {
+
+            get('https://api.meetup.com/2/member/self', {}, function (profile) {
+
+                credentials.profile = profile;
+                return callback();
+            });
+        }
+    };
+};

--- a/test/providers/meetup.js
+++ b/test/providers/meetup.js
@@ -1,0 +1,97 @@
+// Load modules
+
+var Bell = require('../../');
+var Code = require('code');
+var Hapi = require('hapi');
+var Hoek = require('hoek');
+var Lab = require('lab');
+var Mock = require('../mock');
+
+
+// Declare internals
+
+var internals = {};
+
+
+// Test shortcuts
+
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var expect = Code.expect;
+
+
+describe('meetup', function () {
+
+    it('authenticates with mock', { parallel: false }, function (done) {
+
+        var mock = new Mock.V2();
+        mock.start(function (provider) {
+
+            var server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, function (err) {
+
+                expect(err).to.not.exist();
+
+                var custom = Bell.providers.meetup();
+                Hoek.merge(custom, provider);
+
+                var profile = {
+                    id: '1234567890',
+                    name: 'John Doe',
+                    city: 'New York',
+                    country: 'us'
+                };
+
+                Mock.override('https://api.meetup.com/2/member/self', profile);
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'password',
+                    isSecure: false,
+                    clientId: 'meetup',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', function (res) {
+
+                    var cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, function (mockRes) {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, function (response) {
+
+                            Mock.clear();
+                            expect(response.result).to.deep.equal({
+                                provider: 'custom',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    name: 'John Doe',
+                                    city: 'New York',
+                                    country: 'us'
+                                }
+                            });
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/providers/meetup.js
+++ b/test/providers/meetup.js
@@ -87,6 +87,7 @@ describe('meetup', function () {
                                     country: 'us'
                                 }
                             });
+
                             mock.stop(done);
                         });
                     });


### PR DESCRIPTION
Using login with meetup.com for a project of mine, was implementing it using a custom bell provider, but thought others might be interested in this so I've decided to contribute back to bell. :smile: 


`npm test` results
```
...
meetup
  ✔ 71) authenticates with mock (12 ms)
...
79 tests complete
Test duration: 960 ms
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```