### PR TITLE
[github] if github doesn't like auth parameters

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -141,7 +141,7 @@ exports.v2 = function (settings) {
         var state;
 
         // Bail if the upstream service returns an error
-        if (request.query.error === 'access_denied' || request.query.denied || query.error_description) {
+        if (request.query.error === 'access_denied' || request.query.denied || request.query.error_description) {
             return reply(Boom.internal('App was rejected'));
         }
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -25,7 +25,6 @@ exports.v1 = function (settings) {
         var query = request.query;
         var protocol = request.connection.info.protocol;
 
-console.log('0: ' + require('util').inspect(query, { depth: null }));
         // Bail if the upstream service returns an error
 
         if (query.error === 'access_denied' || query.error_description || query.denied) {
@@ -140,7 +139,6 @@ exports.v2 = function (settings) {
         var query;
         var state;
 
-console.log('0: ' + require('util').inspect(request.query, { depth: null }));
         // Bail if the upstream service returns an error
         if (request.query.error === 'access_denied' || request.query.denied || request.query.error_description) {
             return reply(Boom.internal('App was rejected: ' + (query.error_description || query.denied)));
@@ -166,9 +164,6 @@ console.log('0: ' + require('util').inspect(request.query, { depth: null }));
             if (scope) {
                 query.scope = scope.join(settings.provider.scopeSeparator || ' ');
             }
-console.log('1: ' + require('util').inspect(query, { depth: null }));
-console.log('1: ' + require('util').inspect(protocol, { depth: null }));
-console.log('1: ' + require('util').inspect(settings, { depth: null }));
 
             state = {
                 nonce: nonce,
@@ -207,9 +202,6 @@ console.log('1: ' + require('util').inspect(settings, { depth: null }));
             query.client_id = settings.clientId;
             query.client_secret = settings.clientSecret;
         }
-console.log('2: ' + require('util').inspect(query, { depth: null }));
-console.log('2: ' + require('util').inspect(protocol, { depth: null }));
-console.log('2: ' + require('util').inspect(settings, { depth: null }));
 
         var requestOptions = {
             payload: internals.queryString(query),
@@ -228,11 +220,7 @@ console.log('2: ' + require('util').inspect(settings, { depth: null }));
 
         // Obtain token
 
-console.log('2: ' + require('util').inspect(settings.provider.token, { depth: null }));
-console.log('2: ' + require('util').inspect(requestOptions, { depth: null }));
         Wreck.post(settings.provider.token, requestOptions, function (err, tokenRes, payload) {
-console.log('3: ' + tokenRes.statusCode + require('util').inspect(err, { depth: null }));
-console.log('3: ' + require('util').inspect(payload, { depth: null }));
 
             if (err ||
                 tokenRes.statusCode !== 200) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -228,7 +228,11 @@ console.log('2: ' + require('util').inspect(settings, { depth: null }));
 
         // Obtain token
 
+console.log('2: ' + require('util').inspect(settings.provider.token, { depth: null }));
+console.log('2: ' + require('util').inspect(requestOptions, { depth: null }));
         Wreck.post(settings.provider.token, requestOptions, function (err, tokenRes, payload) {
+console.log('3: ' + tokenRes.statusCode + require('util').inspect(err, { depth: null }));
+console.log('3: ' + require('util').inspect(payload, { depth: null }));
 
             if (err ||
                 tokenRes.statusCode !== 200) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -27,8 +27,7 @@ exports.v1 = function (settings) {
 
         // Bail if the upstream service returns an error
 
-        if (query.error === 'access_denied' ||
-            query.denied) {
+        if (query.error === 'access_denied' || query.denied || query.error_description) {
 
             return reply(Boom.internal('Application rejected'));
         }
@@ -142,7 +141,7 @@ exports.v2 = function (settings) {
         var state;
 
         // Bail if the upstream service returns an error
-        if (request.query.error === 'access_denied' || request.query.denied) {
+        if (request.query.error === 'access_denied' || request.query.denied || query.error_description) {
             return reply(Boom.internal('App was rejected'));
         }
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -25,11 +25,11 @@ exports.v1 = function (settings) {
         var query = request.query;
         var protocol = request.connection.info.protocol;
 
+console.log('0: ' + require('util').inspect(query, { depth: null }));
         // Bail if the upstream service returns an error
 
-        if (query.error === 'access_denied' || query.denied || query.error_description) {
-
-            return reply(Boom.internal('Application rejected'));
+        if (query.error === 'access_denied' || query.error_description || query.denied) {
+            return reply(Boom.internal('Application rejected: ' + (query.error_description || query.denied)));
         }
 
         // Sign-in Initialization
@@ -140,9 +140,10 @@ exports.v2 = function (settings) {
         var query;
         var state;
 
+console.log('0: ' + require('util').inspect(request.query, { depth: null }));
         // Bail if the upstream service returns an error
         if (request.query.error === 'access_denied' || request.query.denied || request.query.error_description) {
-            return reply(Boom.internal('App was rejected'));
+            return reply(Boom.internal('App was rejected: ' + (query.error_description || query.denied)));
         }
 
         // Sign-in Initialization
@@ -165,6 +166,9 @@ exports.v2 = function (settings) {
             if (scope) {
                 query.scope = scope.join(settings.provider.scopeSeparator || ' ');
             }
+console.log('1: ' + require('util').inspect(query, { depth: null }));
+console.log('1: ' + require('util').inspect(protocol, { depth: null }));
+console.log('1: ' + require('util').inspect(settings, { depth: null }));
 
             state = {
                 nonce: nonce,
@@ -203,6 +207,9 @@ exports.v2 = function (settings) {
             query.client_id = settings.clientId;
             query.client_secret = settings.clientSecret;
         }
+console.log('2: ' + require('util').inspect(query, { depth: null }));
+console.log('2: ' + require('util').inspect(protocol, { depth: null }));
+console.log('2: ' + require('util').inspect(settings, { depth: null }));
 
         var requestOptions = {
             payload: internals.queryString(query),


### PR DESCRIPTION
it does set `query.error` (but not to `"access_denied"`), it also sets `query.error_description` ... which is what this PR looks for. i think a more general solution is to have an optional function that looks at `request.query` and returns either `null` or `boom.whatever()` ... but, that's outside of my "pay grade"

thanks for the wonderful package!