### PR TITLE
Add error if using non-https server when isSecure is set to true

### DIFF
--- a/API.md
+++ b/API.md
@@ -29,7 +29,7 @@ server.register(require('bell'), function (err) {
         password: 'cookie_encryption_password',
         clientId: 'my_twitter_client_id',
         clientSecret: 'my_twitter_client_secret',
-        isSecure: false     // Terrible idea but required if not using HTTPS
+        isSecure: false     // Terrible idea but required if not using HTTPS especially if developing locally
     });
 
     // Use the 'twitter' authentication strategy to protect the

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ server.register(require('bell'), function (err) {
         provider: 'twitter',
         password: 'cookie_encryption_password',
         clientId: 'my_twitter_client_id',
-        clientSecret: 'my_twitter_client_secret'
+        clientSecret: 'my_twitter_client_secret',
+        isSecure: false     // Terrible idea but required if not using HTTPS especially if developing locally
     });
 
     // Use the 'twitter' authentication strategy to protect the

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -22,10 +22,10 @@ exports.v1 = function (settings) {
 
     return function (request, reply) {
 
-        let cookie = settings.cookie;
-        let name = settings.name;
-        let query = request.query;
-        let protocol = internals.getProtocol(request, settings);
+        const cookie = settings.cookie;
+        const name = settings.name;
+        const query = request.query;
+        const protocol = internals.getProtocol(request, settings);
 
         // Bail if the upstream service returns an error
 
@@ -46,8 +46,8 @@ exports.v1 = function (settings) {
 
             // Obtain temporary OAuth credentials
 
-            var oauth_callback = internals.location(request, protocol, settings.location);
-            return client.temporary(oauth_callback, function (err, payload) {
+            const oauth_callback = internals.location(request, protocol, settings.location);
+            return client.temporary(oauth_callback, (err, payload) => {
 
                 if (err) {
                     return reply(err);
@@ -141,7 +141,7 @@ exports.v2 = function (settings) {
 
         const cookie = settings.cookie;
         const name = settings.name;
-        let protocol = internals.getProtocol(request, settings);
+        const protocol = internals.getProtocol(request, settings);
         let query;
         let state;
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -22,10 +22,10 @@ exports.v1 = function (settings) {
 
     return function (request, reply) {
 
-        var cookie = settings.cookie;
-        var name = settings.name;
-        var query = request.query;
-        var protocol;
+        let cookie = settings.cookie;
+        let name = settings.name;
+        let query = request.query;
+        let protocol = internals.getProtocol(request, settings);
 
         // Bail if the upstream service returns an error
 
@@ -34,9 +34,6 @@ exports.v1 = function (settings) {
 
             return reply(Boom.internal('Application rejected'));
         }
-
-        // Check that the protocol is http or https
-        protocol = internals.getProtocol(request, settings);
 
         // If not https but cookie is secure, throw error
         if (protocol !== 'https' && settings.isSecure) {
@@ -144,7 +141,7 @@ exports.v2 = function (settings) {
 
         const cookie = settings.cookie;
         const name = settings.name;
-        let protocol;
+        let protocol = internals.getProtocol(request, settings);
         let query;
         let state;
 
@@ -152,9 +149,6 @@ exports.v2 = function (settings) {
         if (request.query.error === 'access_denied' || request.query.denied) {
             return reply(Boom.internal('App was rejected'));
         }
-
-        // Check that the protocol is http or https
-        protocol = internals.getProtocol(request, settings);
 
         // If not https but cookie is secure, throw error
         if (protocol !== 'https' && settings.isSecure) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -22,10 +22,10 @@ exports.v1 = function (settings) {
 
     return function (request, reply) {
 
-        const cookie = settings.cookie;
-        const name = settings.name;
-        const query = request.query;
-        let protocol = request.connection.info.protocol;
+        var cookie = settings.cookie;
+        var name = settings.name;
+        var query = request.query;
+        var protocol;
 
         // Bail if the upstream service returns an error
 
@@ -35,17 +35,22 @@ exports.v1 = function (settings) {
             return reply(Boom.internal('Application rejected'));
         }
 
+        // Check that the protocol is http or https
+        protocol = internals.getProtocol(request, settings);
+
+        // If not https but cookie is secure, throw error
+        if (protocol !== 'https' && settings.isSecure) {
+            return reply(Boom.internal('Invalid setting  - isSecure must be set to false for non-https server'));
+        }
+
         // Sign-in Initialization
 
         if (!request.query.oauth_token) {
 
             // Obtain temporary OAuth credentials
 
-            if (settings.forceHttps) {
-                protocol = 'https';
-            }
-            const oauth_callback = internals.location(request, protocol, settings.location);
-            return client.temporary(oauth_callback, (err, payload) => {
+            var oauth_callback = internals.location(request, protocol, settings.location);
+            return client.temporary(oauth_callback, function (err, payload) {
 
                 if (err) {
                     return reply(err);
@@ -148,6 +153,14 @@ exports.v2 = function (settings) {
             return reply(Boom.internal('App was rejected'));
         }
 
+        // Check that the protocol is http or https
+        protocol = internals.getProtocol(request, settings);
+
+        // If not https but cookie is secure, throw error
+        if (protocol !== 'https' && settings.isSecure) {
+            return reply(Boom.internal('Invalid setting  - isSecure must be set to false for non-https server'));
+        }
+
         // Sign-in Initialization
 
         if (!request.query.code) {
@@ -158,7 +171,6 @@ exports.v2 = function (settings) {
                 Hoek.merge(query, request.query);
             }
 
-            protocol = settings.forceHttps ? 'https' : request.connection.info.protocol;
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
@@ -189,11 +201,6 @@ exports.v2 = function (settings) {
 
         if (state.nonce !== request.query.state) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
-        }
-
-        protocol = request.connection.info.protocol;
-        if (settings.forceHttps) {
-            protocol = 'https';
         }
 
         query = {
@@ -427,8 +434,7 @@ internals.Client.baseUri = function (uri) {
 
     const protocol = resource.protocol.toLowerCase();
     const isDefaultPort = resource.port && ((protocol === 'http:' && resource.port === '80') || (protocol === 'https:' && resource.port === '443'));
-    const baseUri = protocol + '//' + resource.hostname.toLowerCase() + (isDefaultPort || !resource.port ? '' : ':' + resource.port) + resource.pathname;
-    return baseUri;
+    return protocol + '//' + resource.hostname.toLowerCase() + (isDefaultPort || !resource.port ? '' : ':' + resource.port) + resource.pathname;
 };
 
 
@@ -589,6 +595,13 @@ internals.Client.queryString = internals.queryString = function (params) {
         }
     }
 
-    const qs = fields.join('&');
-    return qs;
+    return fields.join('&');
+};
+
+internals.getProtocol = (request, settings) => {
+
+    return settings.forceHttps ? 'https' : (
+        settings.location &&
+        settings.location.indexOf('https:') !== -1
+    ) ? 'https' : request.connection.info.protocol;
 };

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -511,6 +511,7 @@ describe('Bell', () => {
         });
 
         it('errors if isSecure is true when protocol is not https', (done) => {
+
             const mock = new Mock.V1();
             mock.start((provider) => {
 
@@ -651,7 +652,7 @@ describe('Bell', () => {
             });
         });
 
-        it('forces https in callback_url when set in options', function (done) {
+        it('forces https in callback_url when set in options', (done) => {
 
             const mock = new Mock.V1();
             mock.start((provider) => {
@@ -1699,6 +1700,7 @@ describe('Bell', () => {
                     });
 
                     server.inject('/login', (res) => {
+
                         expect(res.statusCode).to.equal(500);
                         done();
                     });
@@ -1812,7 +1814,7 @@ describe('Bell', () => {
             });
         });
 
-        it('passes profile get params', { parallel: false }, function (done) {
+        it('passes profile get params', { parallel: false }, (done) => {
 
             const mock = new Mock.V2();
             mock.start((provider) => {

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -510,7 +510,148 @@ describe('Bell', () => {
             });
         });
 
-        it('forces https in callback_url when set in options', (done) => {
+        it('errors if isSecure is true when protocol is not https', (done) => {
+            const mock = new Mock.V1();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: true,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        expect(res.statusCode).to.equal(500);
+                        done();
+                    });
+                });
+            });
+        });
+
+
+        it('passes if isSecure is true when protocol is https (forced)', (done) => {
+
+            const mock = new Mock.V1();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        isSecure: true,
+                        password: 'password',
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        forceHttps: true
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            expect(mockRes.headers.location).to.contain('https://localhost:80/login?oauth_token=1&oauth_verifier=');
+
+                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                                expect(response.statusCode).to.equal(200);
+                                mock.stop(done);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('passes if isSecure is true when protocol is https (location)', (done) => {
+
+            const mock = new Mock.V1();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: true,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        location: 'https://differenthost:8888'
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            expect(mockRes.headers.location).to.contain('https://differenthost:8888/login?oauth_token=1&oauth_verifier=');
+
+                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                                expect(response.statusCode).to.equal(200);
+                                mock.stop(done);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('forces https in callback_url when set in options', function (done) {
 
             const mock = new Mock.V1();
             mock.start((provider) => {
@@ -1525,7 +1666,153 @@ describe('Bell', () => {
             });
         });
 
-        it('passes profile get params', { parallel: false }, (done) => {
+        it('errors if isSecure is true when protocol is not https', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: true,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        providerParams: { special: true }
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+                        expect(res.statusCode).to.equal(500);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('passes if isSecure is true when protocol is https (location)', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: true,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        providerParams: { special: true },
+                        location: 'https://differenthost:8888'
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Fdifferenthost%3A8888%2Flogin&state=');
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            expect(mockRes.headers.location).to.contain('https://differenthost:8888/login?code=1&state=');
+
+                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                                expect(response.statusCode).to.equal(200);
+                                mock.stop(done);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('passes if isSecure is true when protocol is https (forced)', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: true,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        providerParams: { special: true },
+                        forceHttps: true
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: (request, reply) => {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            expect(mockRes.headers.location).to.contain('https://localhost:80/login?code=1&state=');
+
+                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                                expect(response.statusCode).to.equal(200);
+                                mock.stop(done);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('passes profile get params', { parallel: false }, function (done) {
 
             const mock = new Mock.V2();
             mock.start((provider) => {


### PR DESCRIPTION
Today I've spent most of my morning digging around the Hapi internals to find why the state cookie was being destroyed, only to find that it was because I'm developing locally using http, but had not set `isSecure: false` in the options.

The issue is that the error about the cookie not being set at [line 77](https://github.com/hapijs/bell#/L77) isn't too helpful.  Took me into Hapi's own request internals because I was seeing on the outgoing request when I did console.log

```
{ 'bell-twitter':
   { name: 'bell-twitter',
     value:
      { token: '<token>',
        secret: '<secret>',
        query: {} } } }
Debug: internal, implementation, error
    TypeError: Cannot read property 'cookies' of undefined
    at [object Object].internals.Request.internals.Request._execute.internals.Request._lifecycle.internals.Request._invoke.internals.Request._reply.internals.Request._finalize (D:\Documents\GitHub\myapp\node_modules\hapi\lib\request.js:473:28)
```

Then on the request back from twitter:

```
{ undefined: '' }
{}
```

It was quite unhelpful.  Hopefully making this message explicit will make it easier for other people to avoid the same mistake