### PR TITLE
vk provider updated. Email field added to profile object.

### DIFF
--- a/lib/providers/vk.js
+++ b/lib/providers/vk.js
@@ -27,6 +27,12 @@ exports = module.exports = function (options) {
                     raw: profile
                 };
 
+                // If we use 'email' permission at scope, we'll get it on https://oauth.vk.com/access_token request only.
+                // There is no way to get email on https://api.vk.com/method/users.get request.
+                if (params.email) {
+                    credentials.profile.email = params.email;
+                }
+
                 return callback();
             });
         }


### PR DESCRIPTION
In case of VK provider we can get users email on https://oauth.vk.com/access_token request only. So we should pass it to profile object.