### PR TITLE
Allow passing additional state

### DIFF
--- a/API.md
+++ b/API.md
@@ -122,6 +122,7 @@ Each strategy accepts the following optional settings:
 - `profileParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
+- `allowRuntimeState` - allows passing additional state by query parameter which will be encoded into the **bell** state.
 
 ### Advanced Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,8 @@ internals.schema = Joi.object({
     config: Joi.object(),
     profileParams: Joi.object(),
     forceHttps: Joi.boolean().optional().default(false),
-    location: Joi.string().optional().default(false)
+    location: Joi.string().optional().default(false),
+    allowRuntimeState: Joi.boolean().default(false)
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -165,12 +165,12 @@ exports.v2 = function (settings) {
             if (settings.allowRuntimeProviderParams ) {
                 Hoek.merge(query, request.query);
             }
-            
+
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
             query.state = [nonce];
-            
+
             if (settings.allowRuntimeState && request.query.state) {
                 query.state.push(request.query.state);
             }
@@ -202,10 +202,11 @@ exports.v2 = function (settings) {
         try {
             // get nonce back from state array
             request.query.state = JSON.parse(Hoek.base64urlDecode(request.query.state)).shift();
-        } catch(e) {
+        }
+        catch (e) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter format'));
         }
-        
+
         if (state.nonce !== request.query.state) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
         }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -165,11 +165,16 @@ exports.v2 = function (settings) {
             if (settings.allowRuntimeProviderParams ) {
                 Hoek.merge(query, request.query);
             }
-
+            
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
-            query.state = nonce;
+            query.state = [nonce];
+            
+            if (settings.allowRuntimeState && request.query.state) {
+                query.state.push(request.query.state);
+            }
+            query.state = Hoek.base64urlEncode(JSON.stringify(query.state));
 
             const scope = settings.scope || settings.provider.scope;
             if (scope) {
@@ -194,6 +199,13 @@ exports.v2 = function (settings) {
 
         reply.unstate(cookie);
 
+        try {
+            // get nonce back from state array
+            request.query.state = JSON.parse(Hoek.base64urlDecode(request.query.state)).shift();
+        } catch(e) {
+            return reply(Boom.internal('Incorrect ' + name + ' state parameter format'));
+        }
+        
         if (state.nonce !== request.query.state) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
         }


### PR DESCRIPTION
I'd like to add additional data to the OAuth state parameter. So far bell creates its state parameter by using an arbitrary nonce and there is no way for intercepting or extending the state.

This is useful due to restrictions on OAuth redirect_uri. Each provider has its own rules for the callback uri. E.g. OneDrive only allows urls from within a master domain. This makes development and testing complicated: I need to change allowed redirect uris for this. Also if you like to host multiple instances of an application on different domains, things get complicated - at least, or cannot be solved (OneDrive example). By passing additional data a central redirect location can decide where to forward a successful authorization request. Use the bell 'location' setting for this and provide your data by a state query parameter. Also you need to switch on this extension with 'allowRuntimeState'.