### PR TITLE
Allow passing additional state

### DIFF
--- a/API.md
+++ b/API.md
@@ -122,6 +122,7 @@ Each strategy accepts the following optional settings:
 - `profileParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
+- `allowRuntimeState` - allows passing additional state by query parameter which will be encoded into the **bell** state.
 
 ### Advanced Usage
 

--- a/API.md
+++ b/API.md
@@ -122,7 +122,7 @@ Each strategy accepts the following optional settings:
 - `profileParams` - an object of key-value pairs that specify additional URL query parameters to send with the profile request to the provider.
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
-- `allowRuntimeState` - allows passing additional state by query parameter which will be encoded into the **bell** state.
+- `runtimeStateCallback` - allows passing additional OAuth state from initial request. This must be a function returning a string, which will be appended to the **bell** internal `state` parameter for OAuth code flow.
 
 ### Advanced Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,8 @@ internals.schema = Joi.object({
     config: Joi.object(),
     profileParams: Joi.object(),
     forceHttps: Joi.boolean().optional().default(false),
-    location: Joi.string().optional().default(false)
+    location: Joi.string().optional().default(false),
+    allowRuntimeState: Joi.boolean().default(false)
 });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ internals.schema = Joi.object({
     profileParams: Joi.object(),
     forceHttps: Joi.boolean().optional().default(false),
     location: Joi.string().optional().default(false),
-    runtimeStateCallback: Joi.func().arity(1).optional()
+    runtimeStateCallback: Joi.func().optional()
 });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ internals.schema = Joi.object({
     profileParams: Joi.object(),
     forceHttps: Joi.boolean().optional().default(false),
     location: Joi.string().optional().default(false),
-    allowRuntimeState: Joi.boolean().default(false)
+    runtimeStateCallback: Joi.func().arity(1).optional()
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -165,12 +165,12 @@ exports.v2 = function (settings) {
             if (settings.allowRuntimeProviderParams ) {
                 Hoek.merge(query, request.query);
             }
-            
+
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
             query.state = [nonce];
-            
+
             if (settings.allowRuntimeState && request.query.state) {
                 query.state.push(request.query.state);
             }
@@ -202,10 +202,11 @@ exports.v2 = function (settings) {
         try {
             // get nonce back from state array
             request.query.state = JSON.parse(Hoek.base64urlDecode(request.query.state)).shift();
-        } catch(e) {
+        }
+        catch (e) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter format'));
         }
-        
+
         if (state.nonce !== request.query.state) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
         }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -165,11 +165,16 @@ exports.v2 = function (settings) {
             if (settings.allowRuntimeProviderParams ) {
                 Hoek.merge(query, request.query);
             }
-
+            
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
-            query.state = nonce;
+            query.state = [nonce];
+            
+            if (settings.allowRuntimeState && request.query.state) {
+                query.state.push(request.query.state);
+            }
+            query.state = Hoek.base64urlEncode(JSON.stringify(query.state));
 
             const scope = settings.scope || settings.provider.scope;
             if (scope) {
@@ -194,6 +199,13 @@ exports.v2 = function (settings) {
 
         reply.unstate(cookie);
 
+        try {
+            // get nonce back from state array
+            request.query.state = JSON.parse(Hoek.base64urlDecode(request.query.state)).shift();
+        } catch(e) {
+            return reply(Boom.internal('Incorrect ' + name + ' state parameter format'));
+        }
+        
         if (state.nonce !== request.query.state) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
         }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -13,7 +13,9 @@ const Wreck = require('wreck');
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    nonceLength: 22
+};
 
 
 exports.v1 = function (settings) {
@@ -159,7 +161,7 @@ exports.v2 = function (settings) {
         // Sign-in Initialization
 
         if (!request.query.code) {
-            const nonce = Cryptiles.randomString(22);
+            const nonce = Cryptiles.randomString(internals.nonceLength);
             query = Hoek.clone(settings.providerParams) || {};
 
             if (settings.allowRuntimeProviderParams ) {
@@ -169,12 +171,14 @@ exports.v2 = function (settings) {
             query.client_id = settings.clientId;
             query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
-            query.state = [nonce];
+            query.state = nonce;
 
-            if (settings.allowRuntimeState && request.query.state) {
-                query.state.push(request.query.state);
+            if (settings.runtimeStateCallback) {
+                const runtimeState = settings.runtimeStateCallback(request);
+                if (runtimeState) {
+                    query.state += runtimeState;
+                }
             }
-            query.state = Hoek.base64urlEncode(JSON.stringify(query.state));
 
             const scope = settings.scope || settings.provider.scope;
             if (scope) {
@@ -199,15 +203,8 @@ exports.v2 = function (settings) {
 
         reply.unstate(cookie);
 
-        try {
-            // get nonce back from state array
-            request.query.state = JSON.parse(Hoek.base64urlDecode(request.query.state)).shift();
-        }
-        catch (e) {
-            return reply(Boom.internal('Incorrect ' + name + ' state parameter format'));
-        }
-
-        if (state.nonce !== request.query.state) {
+        const requestState = request.query.state || '';
+        if (state.nonce !== requestState.substr(0, Math.min(requestState.length, internals.nonceLength))) {
             return reply(Boom.internal('Incorrect ' + name + ' state parameter'));
         }
 
@@ -364,7 +361,7 @@ internals.Client.prototype._request = function (method, uri, params, oauth, opti
 
     // Prepare generic OAuth parameters
 
-    oauth.oauth_nonce = Cryptiles.randomString(22);
+    oauth.oauth_nonce = Cryptiles.randomString(internals.nonceLength);
     oauth.oauth_timestamp = Math.floor(Date.now() / 1000).toString();
     oauth.oauth_consumer_key = this.settings.clientId;
     oauth.oauth_signature_method = 'HMAC-SHA1';

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1129,7 +1129,56 @@ describe('Bell', () => {
                         clientSecret: 'secret',
                         provider: provider,
                         providerParams: { special: true },
-                        allowRuntimeState: true
+                        runtimeStateCallback: function (request) {
+
+                            return request.query.state;
+                        }
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: function (request, reply) {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login?state=something', (res) => {
+
+                        expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+                        expect(res.headers.location).to.contain('something');
+                        mock.stop(done);
+                    });
+                });
+            });
+        });
+
+        it('allows empty or null runtime state', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: false,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider,
+                        providerParams: { special: true },
+                        runtimeStateCallback: function (request) {
+
+                            return null;
+                        }
                     });
 
                     server.route({
@@ -1148,6 +1197,57 @@ describe('Bell', () => {
 
                         expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
                         mock.stop(done);
+                    });
+                });
+            });
+        });
+
+        it('fails on missing state', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'password',
+                        isSecure: false,
+                        clientId: 'test',
+                        clientSecret: 'secret',
+                        provider: provider
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: function (request, reply) {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                        expect(res.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            expect(mockRes.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+
+                            server.inject({ url: 'http://localhost:80/login?code=1', headers: { cookie: cookie } }, (response) => {
+
+                                expect(response.statusCode).to.equal(500);
+                                mock.stop(done);
+                            });
+                        });
                     });
                 });
             });
@@ -1286,58 +1386,7 @@ describe('Bell', () => {
 
                             expect(mockRes.headers.location).to.contain('http://localhost:80/login?code=1&state=');
 
-                            server.inject({ url: 'http://localhost:80/login?code=1&state=W10', headers: { cookie: cookie } }, (response) => {
-
-                                expect(response.statusCode).to.equal(500);
-                                mock.stop(done);
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        it('errors on invalid state', (done) => {
-
-            const mock = new Mock.V2();
-            mock.start((provider) => {
-
-                const server = new Hapi.Server();
-                server.connection({ host: 'localhost', port: 80 });
-                server.register(Bell, (err) => {
-
-                    expect(err).to.not.exist();
-
-                    server.auth.strategy('custom', 'bell', {
-                        password: 'password',
-                        isSecure: false,
-                        clientId: 'test',
-                        clientSecret: 'secret',
-                        provider: provider
-                    });
-
-                    server.route({
-                        method: '*',
-                        path: '/login',
-                        config: {
-                            auth: 'custom',
-                            handler: function (request, reply) {
-
-                                reply(request.auth.credentials);
-                            }
-                        }
-                    });
-
-                    server.inject('/login', (res) => {
-
-                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
-                        expect(res.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
-
-                        mock.server.inject(res.headers.location, (mockRes) => {
-
-                            expect(mockRes.headers.location).to.contain('http://localhost:80/login?code=1&state=');
-
-                            server.inject({ url: mockRes.headers.location + 'xx', headers: { cookie: cookie } }, (response) => {
+                            server.inject({ url: 'http://localhost:80/login?code=1&state=xx', headers: { cookie: cookie } }, (response) => {
 
                                 expect(response.statusCode).to.equal(500);
                                 mock.stop(done);

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1123,7 +1123,7 @@ describe('Bell', () => {
                     expect(err).to.not.exist();
 
                     server.auth.strategy('custom', 'bell', {
-                        password: 'password',
+                        password: 'cookie_encryption_password_secure',
                         isSecure: false,
                         clientId: 'test',
                         clientSecret: 'secret',
@@ -1169,7 +1169,7 @@ describe('Bell', () => {
                     expect(err).to.not.exist();
 
                     server.auth.strategy('custom', 'bell', {
-                        password: 'password',
+                        password: 'cookie_encryption_password_secure',
                         isSecure: false,
                         clientId: 'test',
                         clientSecret: 'secret',
@@ -1214,7 +1214,7 @@ describe('Bell', () => {
                     expect(err).to.not.exist();
 
                     server.auth.strategy('custom', 'bell', {
-                        password: 'password',
+                        password: 'cookie_encryption_password_secure',
                         isSecure: false,
                         clientId: 'test',
                         clientSecret: 'secret',


### PR DESCRIPTION
I'd like to add additional data to the OAuth state parameter. So far bell creates its state parameter by using an arbitrary nonce and there is no way for intercepting or extending the state.

This is useful due to restrictions on OAuth redirect_uri. Each provider has its own rules for the callback uri. E.g. OneDrive only allows urls from within a master domain. This makes development and testing complicated: I need to change allowed redirect uris for this. Also if you like to host multiple instances of an application on different domains, things get complicated - at least, or cannot be solved (OneDrive example). By passing additional data a central redirect location can decide where to forward a successful authorization request. Use the bell 'location' setting for this and provide your data by a state query parameter. Also you need to switch on this extension via 'allowRuntimeState'.