### PR TITLE
skipProfile option

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,6 +115,7 @@ Each strategy accepts the following optional settings:
 - `allowRuntimeProviderParams` - allows passing query parameters from a **bell** protected endpoint to the auth request. It will merge the query params you pass along with the providerParams and any other predefined ones. Be aware that this will override predefined query parameters! Default to `false`.
 - `scope` - Each built-in vendor comes with the required scope for basic profile information. Use `scope` to specify a different scope
   as required by your application. Consult the provider for their specific supported scopes.
+- `skipProfile` - skips obtaining a user profile from the provider. Useful if you need specific `scope`s, but not the user profile. Defaults to `false`.
 - `config` - a configuration object used to customize the provider settings. The built-in `'twitter'` provider accepts the `extendedProfile`
   option which allows disabling the extra profile request when the provider returns the user information in the callback (defaults to `true`).
   The built-in `'github'` and `'phabricator'` providers accept the `uri` option which allows pointing to a private enterprise installation

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,7 @@ internals.schema = Joi.object({
     name: Joi.string().required(),
     config: Joi.object(),
     profileParams: Joi.object(),
+    skipProfile: Joi.boolean().optional().default(false),
     forceHttps: Joi.boolean().optional().default(false),
     location: Joi.string().optional().default(false)
 });

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -105,7 +105,7 @@ exports.v1 = function (settings) {
                 query: state.query
             };
 
-            if (!settings.provider.profile) {
+            if (!settings.provider.profile || settings.skipProfile) {
                 return reply.continue({ credentials: credentials });
             }
 
@@ -247,7 +247,7 @@ exports.v2 = function (settings) {
                 query: state.query
             };
 
-            if (!settings.provider.profile) {
+            if (!settings.provider.profile || settings.skipProfile) {
                 return reply.continue({ credentials: credentials });
             }
 


### PR DESCRIPTION
There are some cases when I want to use bell with OAuth scopes that don't include the profile. For example, I'm using the Google Calendar scope, but not the profile scope, so bell wouldn't be able to fetch the profile. This lets the user skip fetching the profile from their provider config, without having to write a new provider with their blank `profile` function.