### PR TITLE
Bitbucket incorrect id and styling inconsistency.

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -78,11 +78,12 @@ Specific fields may vary depending on the identity provider used. For more infor
 The default profile response will look like this:
 
 ```javascript
-credentials.profile = {};
-credentials.profile.id = profile.username;
-credentials.profile.username = profile.username;
-credentials.profile.displayName = profile.display_name;
-credentials.profile.raw = profile;
+credentials.profile = {
+    id: profile.uuid,
+    username: profile.username,
+    displayName: profile.display_name,
+    raw: profile
+};
 ```
 
 ### Dropbox

--- a/lib/providers/bitbucket.js
+++ b/lib/providers/bitbucket.js
@@ -10,11 +10,12 @@ exports = module.exports = function () {
 
             get('https://api.bitbucket.org/2.0/user', null, (profile) => {
 
-                credentials.profile = {};
-                credentials.profile.id = profile.username;
-                credentials.profile.username = profile.username;
-                credentials.profile.displayName = profile.display_name;
-                credentials.profile.raw = profile;
+                credentials.profile = {
+                    id: profile.uuid,
+                    username: profile.username,
+                    displayName: profile.display_name,
+                    raw: profile
+                };
                 return callback();
             });
         }

--- a/test/providers/bitbucket.js
+++ b/test/providers/bitbucket.js
@@ -36,7 +36,7 @@ describe('bitbucket', () => {
 
                 Mock.override('https://api.bitbucket.org/2.0/user', {
                     repositories: [{}],
-                    id: 'steve',
+                    uuid: '1E9C5160-E436-11E5-9897-4FCB70D5A8C7',
                     username: 'steve',
                     display_name: 'steve'
                 });
@@ -76,12 +76,12 @@ describe('bitbucket', () => {
                                 expiresIn: 3600,
                                 query: {},
                                 profile: {
-                                    id: 'steve',
+                                    id: '1E9C5160-E436-11E5-9897-4FCB70D5A8C7',
                                     username: 'steve',
                                     displayName: 'steve',
                                     raw: {
                                         repositories: [{}],
-                                        id: 'steve',
+                                        uuid: '1E9C5160-E436-11E5-9897-4FCB70D5A8C7',
                                         username: 'steve',
                                         display_name: 'steve'
                                     }


### PR DESCRIPTION
Not sure why this wasn't picked up in the PR, but there are a couple issues.
1. It seems `profile.uuid` should be used instead of `profile.username` for `credentials.profile.id`.
2. The style in which this was written differs from the other providers we have.

I've gone ahead and fixed both issues in this PR.