### PR TITLE
Fix Safari CORS with Facebook & potentially other providers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+    "extends": "hapi"
+}

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -197,8 +197,13 @@ exports.v2 = function (settings) {
         // Authorization callback
 
         state = request.state[cookie];
-        if (!state) {
-            return reply(Boom.internal('Missing ' + name + ' request token cookie'));
+		if (!state) {
+            if (request.query && request.query.refresh === 1) {
+                return reply(Boom.internal('Missing ' + name + ' request token cookie'));
+            } else {
+                var url = request.connection.info.protocol + '://' + request.info.host + request.url.path + '&refresh=1';
+                return reply('<html><head><meta http-equiv="refresh" content="0;URL=\'' + url + '\'"></head><body></body></html>');
+            }
         }
 
         reply.unstate(cookie);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -197,13 +197,16 @@ exports.v2 = function (settings) {
         // Authorization callback
 
         state = request.state[cookie];
-		if (!state) {
-            if (request.query && request.query.refresh === 1) {
+        if (!state) {
+            if (request.query.refresh) {
                 return reply(Boom.internal('Missing ' + name + ' request token cookie'));
-            } else {
-                var url = request.connection.info.protocol + '://' + request.info.host + request.url.path + '&refresh=1';
-                return reply('<html><head><meta http-equiv="refresh" content="0;URL=\'' + url + '\'"></head><body></body></html>');
             }
+
+            // Workaround for some browsers where due to CORS and the redirection method,
+            // it will not send the state cookie along until the request comes directly from the same domain
+            const newQuery = Object.assign({}, request.url.query, { refresh: 1 });
+            const refreshUrl = internals.location(request, protocol, settings.location) + '?' + internals.queryString(newQuery);
+            return reply(`<html><head><meta http-equiv="refresh" content="0;URL="${refreshUrl}"></head><body></body></html>`);
         }
 
         reply.unstate(cookie);

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1471,7 +1471,7 @@ describe('Bell', () => {
             });
         });
 
-        it('errors on missing cookie in token step', (done) => {
+        it('refreshes & errors on missing cookie in token step', (done) => {
 
             const mock = new Mock.V2();
             mock.start((provider) => {
@@ -1511,11 +1511,17 @@ describe('Bell', () => {
                         mock.server.inject(res.headers.location, (mockRes) => {
 
                             expect(mockRes.headers.location).to.contain('http://localhost:80/login?code=1&state=');
-
                             server.inject(mockRes.headers.location, (response) => {
 
-                                expect(response.statusCode).to.equal(500);
-                                mock.stop(done);
+                                expect(response.statusCode).to.equal(200);
+                                const newLocation = mockRes.headers.location + '&refresh=1';
+                                expect(response.payload).to.contain(newLocation);
+
+                                server.inject(newLocation, (errorResponse) => {
+
+                                    expect(errorResponse.statusCode).to.equal(500);
+                                    mock.stop(done);
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
Based on #206 and Fixes #191.

Could I get someone to review this?

The crux of the issue is that Safari, due to CORS and the way Facebook sometimes does the redirect, it will not send the state cookie along. So, when we see no token (usually happens during development due to bad settings), we attempt to refresh the page using the meta keyword (not using javascript) and this ensures that Safari sends us the cookie.

We attempt to not have infinite loops with adding the refresh query parameter.