### PR TITLE
Add Pinterest provider

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,7 +65,7 @@ server.register(require('bell'), function (err) {
 ### Options
 
 The `server.auth.strategy()` method requires the following strategy options:
-- `provider` - the name of the third-party provider (`'auth0'`, `'bitbucket'`, `'dropbox'`, `'facebook'`, `'foursquare'`, `'github'`, `'google'`, `'instagram'`, `'linkedin'`, `'live'`, `'twitter'`, `'vk'`, `'arcgisonline'`, `'yahoo'`, `'nest'`, `'phabricator'`, `'office365'`)
+- `provider` - the name of the third-party provider (`'auth0'`, `'bitbucket'`, `'dropbox'`, `'facebook'`, `'foursquare'`, `'github'`, `'google'`, `'instagram'`, `'linkedin'`, `'live'`, `'twitter'`, `'vk'`, `'arcgisonline'`, `'yahoo'`, `'nest'`, `'phabricator'`, `'office365'`, `'pinterest'`)
   or an object containing a custom provider with the following:
     - `protocol` - the authorization protocol used. Must be one of:
         - `'oauth'` - OAuth 1.0a

--- a/Providers.md
+++ b/Providers.md
@@ -347,6 +347,29 @@ credentials.profile = {
 };
 ```
 
+### Pinterest
+
+[Provider Documentation](https://developers.pinterest.com/docs/api/overview/)
+
+- `scope`: Defaults to `['read_public', 'write_public', 'read_relationships', 'write_relationships']`
+- `config`: not applicable
+- `auth`: https://api.pinterest.com/oauth/
+- `token`: https://api.pinterest.com/v1/oauth/token
+
+The default profile response will look like this:
+
+```javascript
+credentials.profile = {
+    id: profile.data.id,
+    username: profile.data.username,
+    name: {
+        first: profile.data.first_name,
+        last: profile.data.last_name
+    },
+    raw: profile
+};
+```
+
 ### Reddit
 
 [Provider Documentation](https://github.com/reddit/reddit/wiki/OAuth2)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lead Maintainer: [Lois Desplat](https://github.com/ldesplat)
 
 [![Build Status](https://secure.travis-ci.org/hapijs/bell.png)](http://travis-ci.org/hapijs/bell)
 
-**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Instagram`, `LinkedIn`, `Slack`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch` and `Salesforce`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
+**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Instagram`, `LinkedIn`, `Slack`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch`, `Salesforce` and `Pinterest`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
 
 ## Documentation
 

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -25,5 +25,6 @@ exports = module.exports = {
     twitch: require('./twitch'),
     salesforce: require('./salesforce'),
     wordpress: require('./wordpress'),
-    office365: require('./office365')
+    office365: require('./office365'),
+    pinterest: require('./pinterest')
 };

--- a/lib/providers/pinterest.js
+++ b/lib/providers/pinterest.js
@@ -13,7 +13,7 @@ exports = module.exports = function (options) {
         profile: function (credentials, params, get, callback) {
 
             const query = {
-                fields: 'id,username,first_name,last_name'
+                fields: 'id,username,first_name,last_name,bio,created_at,counts,image'
             };
 
             get('https://api.pinterest.com/v1/me/', query, (profile) => {

--- a/lib/providers/pinterest.js
+++ b/lib/providers/pinterest.js
@@ -1,0 +1,35 @@
+'use strict';
+
+exports = module.exports = function (options) {
+
+    return {
+        name: 'pinterest',
+        protocol: 'oauth2',
+        auth: 'https://api.pinterest.com/oauth/',
+        token: 'https://api.pinterest.com/v1/oauth/token',
+        useParamsAuth: true,
+        scope: ['read_public', 'write_public', 'read_relationships', 'write_relationships'],
+        scopeSeparator: ',',
+        profile: function (credentials, params, get, callback) {
+
+            const query = {
+                fields: 'id,username,first_name,last_name'
+            };
+
+            get('https://api.pinterest.com/v1/me/', query, (profile) => {
+
+                credentials.profile = {
+                    id: profile.data.id,
+                    username: profile.data.username,
+                    name: {
+                        first: profile.data.first_name,
+                        last: profile.data.last_name
+                    },
+                    raw: profile
+                };
+
+                return callback();
+            });
+        }
+    };
+};

--- a/test/providers/pinterest.js
+++ b/test/providers/pinterest.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// Load modules
+
+const Bell = require('../../');
+const Code = require('code');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Mock = require('../mock');
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+describe('pinterest', () => {
+
+    it('authenticates with mock', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const pinterest = Bell.providers.pinterest();
+                Hoek.merge(pinterest, provider);
+
+                const profile = {
+                    data: {
+                        id: '1234567890',
+                        username: 'steve',
+                        first_name: 'steve',
+                        last_name: 'smith'
+                    }
+                };
+
+                Mock.override('https://api.pinterest.com/v1/me/', profile);
+
+                server.auth.strategy('pinterest', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'pinterest',
+                    clientSecret: 'secret',
+                    provider: pinterest
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'pinterest',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.deep.equal({
+                                provider: 'pinterest',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    username: 'steve',
+                                    name: {
+                                        first: 'steve',
+                                        last: 'smith'
+                                    },
+                                    raw: profile
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hi, 
I'm working on a project that needs to support Pinterest for authentication.

Since my team is using Bell to manage other social networks, I thought it would be nice to write a provider for Pinterest on my own and than submit it to you, so other people can use it.

I also wrote the test (100% coverage) and the documentation about it.

If you would like any further information, please don't hesitate to contact me.

Bye
Antonio