### PR TITLE
Consistently return node req object in oauth v1 client. Closes #215

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -334,7 +334,7 @@ internals.Client.prototype.temporary = function (oauth_callback, callback) {
         oauth_callback: oauth_callback
     };
 
-    this._request('post', this.settings.temporary, null, oauth, { desc: 'temporary credentials' }, callback);
+    return this._request('post', this.settings.temporary, null, oauth, { desc: 'temporary credentials' }, callback);
 };
 
 
@@ -347,7 +347,7 @@ internals.Client.prototype.token = function (oauthToken, oauthVerifier, tokenSec
         oauth_verifier: oauthVerifier
     };
 
-    this._request('post', this.settings.token, null, oauth, { secret: tokenSecret, desc: 'token credentials' }, callback);
+    return this._request('post', this.settings.token, null, oauth, { secret: tokenSecret, desc: 'token credentials' }, callback);
 };
 
 
@@ -399,7 +399,7 @@ internals.Client.prototype._request = function (method, uri, params, oauth, opti
     }
 
     const desc = (options.desc || 'resource');
-    Wreck[method](uri, requestOptions, (err, res, payload) => {
+    return Wreck[method](uri, requestOptions, (err, res, payload) => {
 
         if (err) {
             return callback(Boom.internal('Failed obtaining ' + this.provider + ' ' + desc, err));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "boom": "3.x.x",
     "cryptiles": "3.x.x",
-    "hoek": "3.x.x",
+    "hoek": "4.x.x",
     "joi": "8.x.x",
     "wreck": "7.x.x"
   },


### PR DESCRIPTION
This might benefit from some tests confirming that all these methods return a node `req` object. This is needed in case you want to `req.abort()` etc. I don't have the time to add tests but this is probably worth merging and adding a new issue for the missing tests...