### PR TITLE
getMethod option

### DIFF
--- a/API.md
+++ b/API.md
@@ -116,7 +116,7 @@ Each strategy accepts the following optional settings:
 - `scope` - Each built-in vendor comes with the required scope for basic profile information. Use `scope` to specify a different scope
   as required by your application. Consult the provider for their specific supported scopes.
 - `skipProfile` - skips obtaining a user profile from the provider. Useful if you need specific `scope`s, but not the user profile. Defaults to `false`.
-- `config` - a configuration object used to customize the provider settings. The built-in `'twitter'` provider accepts the `extendedProfile`
+- `config` - a configuration object used to customize the provider settings. The built-in `'twitter'` provider accepts the `extendedProfile` & `getMethod` options.
   option which allows disabling the extra profile request when the provider returns the user information in the callback (defaults to `true`).
   The built-in `'github'` and `'phabricator'` providers accept the `uri` option which allows pointing to a private enterprise installation
   (e.g. `'https://vpn.example.com'`). See [Providers documentation](Providers.md) for more information.

--- a/Providers.md
+++ b/Providers.md
@@ -422,7 +422,7 @@ credentials.profile = {
 - `scope`: not applicable
 - `config`:
   - `extendedProfile`: Request for more profile information
-  - `getMethod`: [Twitter API](https://dev.twitter.com/rest/public) GET method to call. Defaults to `'users/show'`
+  - `getMethod`: [Twitter API](https://dev.twitter.com/rest/public) GET method to call when `extendedProfile` is enabled. Defaults to `'users/show'`
 - `temporary`: 'https://api.twitter.com/oauth/request_token'
 - `auth`: https://api.twitter.com/oauth/authenticate
 - `token`: https://api.twitter.com/oauth/access_token

--- a/Providers.md
+++ b/Providers.md
@@ -422,6 +422,7 @@ credentials.profile = {
 - `scope`: not applicable
 - `config`:
   - `extendedProfile`: Request for more profile information
+  - `getMethod`: [Twitter API](https://dev.twitter.com/rest/public) GET method to call. Defaults to `'users/show'`
 - `temporary`: 'https://api.twitter.com/oauth/request_token'
 - `auth`: https://api.twitter.com/oauth/authenticate
 - `token`: https://api.twitter.com/oauth/access_token

--- a/lib/providers/twitter.js
+++ b/lib/providers/twitter.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const Hoek = require('hoek');
+
 exports = module.exports = function (options) {
 
-    options = options || {};
-
-    const getMethod = options.getMethod || 'users/show';
+    const defaults = {
+        extendedProfile: true,
+        getMethod: 'users/show'
+    };
+    const settings = Hoek.applyToDefaults(defaults, options || {});
 
     return {
         protocol: 'oauth',
@@ -18,11 +22,11 @@ exports = module.exports = function (options) {
                 username: params.screen_name
             };
 
-            if (options.extendedProfile === false) {      // Defaults to true
+            if (settings.extendedProfile === false) {      // Defaults to true
                 return callback();
             }
 
-            get('https://api.twitter.com/1.1/' + getMethod + '.json', { user_id: params.user_id }, (profile) => {
+            get(`https://api.twitter.com/1.1/${settings.getMethod}.json`, { user_id: params.user_id }, (profile) => {
 
                 credentials.profile.displayName = profile.name;
                 credentials.profile.raw = profile;

--- a/lib/providers/twitter.js
+++ b/lib/providers/twitter.js
@@ -4,6 +4,8 @@ exports = module.exports = function (options) {
 
     options = options || {};
 
+    const getMethod = options.getMethod || 'users/show';
+
     return {
         protocol: 'oauth',
         temporary: 'https://api.twitter.com/oauth/request_token',
@@ -20,7 +22,7 @@ exports = module.exports = function (options) {
                 return callback();
             }
 
-            get('https://api.twitter.com/1.1/users/show.json', { user_id: params.user_id }, (profile) => {
+            get('https://api.twitter.com/1.1/' + getMethod + '.json', { user_id: params.user_id }, (profile) => {
 
                 credentials.profile.displayName = profile.name;
                 credentials.profile.raw = profile;

--- a/test/providers/twitter.js
+++ b/test/providers/twitter.js
@@ -89,6 +89,75 @@ describe('twitter', () => {
         });
     });
 
+    it('authenticates with mock and custom method', { parallel: false }, (done) => {
+
+        const mock = new Mock.V1();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.twitter({ getMethod: 'custom/method' });
+                Hoek.merge(custom, provider);
+
+                Mock.override('https://api.twitter.com/1.1/custom/method.json', {
+                    property: 'something'
+                });
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'twitter',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.deep.equal({
+                                provider: 'custom',
+                                token: 'final',
+                                secret: 'secret',
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    username: 'Steve Stevens',
+                                    displayName: undefined,
+                                    raw: {
+                                        property: 'something'
+                                    }
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     it('authenticates with mock (without extended profile)', { parallel: false }, (done) => {
 
         const mock = new Mock.V1();

--- a/test/providers/twitter.js
+++ b/test/providers/twitter.js
@@ -135,7 +135,7 @@ describe('twitter', () => {
                         server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
 
                             Mock.clear();
-                            expect(response.result).to.deep.equal({
+                            expect(response.result).to.equal({
                                 provider: 'custom',
                                 token: 'final',
                                 secret: 'secret',


### PR DESCRIPTION
Introduces ``getMethod`` option to Twitter provider in order to allow using different methods from its rest API.