### PR TITLE
Fix markup to quote URL correctly to avoid infinite redirect

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -316,7 +316,7 @@ internals.refreshRedirect = function (request, name, protocol, settings, reply) 
     }
     const refreshQuery = Object.assign({}, request.url.query, { refresh: 1 });
     const refreshUrl = internals.location(request, protocol, settings.location) + '?' + internals.queryString(refreshQuery);
-    return reply(`<html><head><meta http-equiv="refresh" content="0;URL="${refreshUrl}"></head><body></body></html>`);
+    return reply(`<html><head><meta http-equiv="refresh" content="0;URL='${refreshUrl}'"></head><body></body></html>`);
 };
 
 

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -91,7 +91,7 @@ describe('Bell', () => {
                 server.inject('/login?oauth_token=123&oauth_verifier=123', (res) => {
 
                     expect(res.statusCode).to.equal(200);
-                    expect(res.result).to.equal('<html><head><meta http-equiv=\"refresh\" content=\"0;URL=\"http://localhost:80/login?oauth_token=123&oauth_verifier=123&refresh=1\"></head><body></body></html>');
+                    expect(res.result).to.equal('<html><head><meta http-equiv=\"refresh\" content=\"0;URL=\'http://localhost:80/login?oauth_token=123&oauth_verifier=123&refresh=1\'\"></head><body></body></html>');
                     done();
                 });
             });


### PR DESCRIPTION
@ldesplat After the fix for https://github.com/hapijs/bell/pull/208 it looks like at least on chrome it's possible to simulate an infinite redirect. It's triggered by unbalanced quotes used in the markup which make the current browser location be the redirect url without the refresh param. I've updated the markup to be similar to the [W3 Example](https://www.w3.org/TR/WCAG20-TECHS/H76.html#H76-examples) to avoid the infinite redirect