### PR TITLE
Allow use of non-Google+ profile endpoints. (fixes #228)

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -193,10 +193,13 @@ The default profile response will look like this:
 
 [Provider Documentation](https://developers.google.com/identity/protocols/OpenIDConnect)
 
-You must also enable the Google+ API in your profile. Go to APIs & Auth, then APIs and under Social APIs click Google+ API and enable it.
+By default the Google provider uses a Google+ API to access a users profile. Using Google+ APIs requires developers to enable the Google+ API in the Google Developer Console. Go to APIs & Auth, then APIs and under Social APIs click Google+ API and enable it.
+
+Alternatively you may use the `profileUrl` config to fetch a users standard Google Account details. At the time of writing, [https://www.googleapis.com/oauth2/v3/userinfo](https://www.googleapis.com/oauth2/v3/userinfo) is the latest version of the alternative user profile endpoint.
 
 - `scope`: Defaults to `['profile', 'email']`
-- `config`: not applicable
+- `config`:
+  - `profileUrl`: String *optional* alternative to the default Google+ API profile URL. (use this if you wish to fetch non-Google+ profile data.)
 - `auth`: https://accounts.google.com/o/oauth2/v2/auth
 - `token`: https://www.googleapis.com/oauth2/v4/token
 
@@ -208,6 +211,20 @@ credentials.profile = {
     displayName: profile.displayName,
     name: profile.name,
     emails: profile.emails,
+    raw: profile
+};
+```
+
+Non-Google+ profile response will look like this:
+```javascript
+credentials.profile = {
+    id: profile.id,
+    displayName: profile.name,
+    name: {
+        given_name: profile.given_name,
+        family_name: profile.family_name
+    },
+    email: profile.email,
     raw: profile
 };
 ```

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -2,6 +2,36 @@
 
 exports = module.exports = function (options) {
 
+    options = options || {};
+
+    const extractProfile = function (profile, profileUrl) {
+
+        let ret;
+        if (profileUrl.indexOf('plus') === -1) {
+            //standard google profile information
+            ret = Object.assign({}, {
+                displayName: profile.name,
+                name: {
+                    given_name: profile.given_name,
+                    family_name: profile.family_name
+                },
+                email: profile.email
+            });
+        }
+        else {
+            //google plus profile information
+            ret = Object.assign({}, {
+                displayName: profile.displayName,
+                name: profile.name,
+                emails: profile.emails
+            });
+        }
+        return Object.assign(ret, {
+            id: profile.id,
+            raw: profile
+        });
+    };
+
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
@@ -10,16 +40,10 @@ exports = module.exports = function (options) {
         scope: ['profile', 'email'],
         profile: function (credentials, params, get, callback) {
 
-            get('https://www.googleapis.com/plus/v1/people/me', null, (profile) => {
+            const profileUrl = options.profileUrl || 'https://www.googleapis.com/plus/v1/people/me';
+            get(profileUrl, null, (profile) => {
 
-                credentials.profile = {
-                    id: profile.id,
-                    displayName: profile.displayName,
-                    name: profile.name,
-                    emails: profile.emails,
-                    raw: profile
-                };
-
+                credentials.profile = extractProfile(profile, profileUrl);
                 return callback();
             });
         }

--- a/test/providers/google.js
+++ b/test/providers/google.js
@@ -109,4 +109,84 @@ describe('google', () => {
             });
         });
     });
+
+    it('Uses custom profileUrl', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.google({
+                    profileUrl: 'https://www.googleapis.com/oauth2/v3/userinfo'
+                });
+                Hoek.merge(custom, provider);
+
+                const profile = {
+                    id: '1234567890',
+                    name: 'steve smith',
+                    given_name: 'steve',
+                    family_name: 'smith',
+                    email: 'steve@example.com'
+                };
+
+                Mock.override('https://www.googleapis.com/oauth2/v3/userinfo', profile);
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'google',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    displayName: 'steve smith',
+                                    name: {
+                                        given_name: 'steve',
+                                        family_name: 'smith'
+                                    },
+                                    email: 'steve@example.com',
+                                    raw: profile
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Fix for #228, allows developers to use profile URLs that don't depend on Google+ APIs being enabled.

See #228 for more details.

I implemented this change as an optional parameter in order to ensure it didn't change the default behavior of the Google provider. This ensures that the change can land without requiring a major version bump.