### PR TITLE
[Fix] Fixes email address field in LinkedIn

### DIFF
--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -34,7 +34,7 @@ exports = module.exports = function (options) {
                         first: profile.firstName,
                         last: profile.lastName
                     },
-                    email: profile.email,
+                    email: profile.emailAddress,
                     headline: profile.headline,
                     raw: profile
                 };


### PR DESCRIPTION
Fixes email address field in LinkedIn.  Raw profile output:
raw:
   {
     emailAddress: 'kamronsEmailHere',
     firstName: 'Kamron',
     id: 'NUMBER_HERE',
     lastName: 'Batman',
}