### PR TITLE
New dropbox-v2 provider which uses Dropbox V2 API

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,6 +83,7 @@ The `server.auth.strategy()` method requires the following strategy options:
       Defaults to space (Facebook and GitHub default to comma).
     - `headers` - a headers object with additional headers required by the provider (e.g. GitHub required the 'User-Agent' header which is
       set by default).
+    - `profileMethod` - `get` or `post` for obtaining user profile by `profile` function. Default is `get`.
     - `profile` - a function used to obtain user profile information and normalize it. The function signature is
       `function(credentials, params, get, callback)` where:
         - `credentials` - the credentials object. Change the object directly within the function (profile information is typically stored
@@ -94,6 +95,7 @@ The `server.auth.strategy()` method requires the following strategy options:
             - `params` - any URI query parameters (cannot include them in the URI due to signature requirements).
             - `callback` - request callback with signature `function(response)` where `response` is the parsed payload (any errors are
               handled internally).
+          If `profileMethod` is set to `post` the helper function sends a POST request for obtaining the user profile.
         - `callback` - the callback function which much be called once profile processing is complete.
 - `password` - the cookie encryption password. Used to encrypt the temporary state cookie used by the module in between the authorization
   protocol steps.

--- a/API.md
+++ b/API.md
@@ -127,7 +127,6 @@ Each strategy accepts the following optional settings:
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
 - `runtimeStateCallback` - allows passing additional OAuth state from initial request. This must be a function returning a string, which will be appended to the **bell** internal `state` parameter for OAuth code flow.
-- `agent` - Agent for `Wreck` requests.
 
 ### Advanced Usage
 

--- a/API.md
+++ b/API.md
@@ -127,6 +127,7 @@ Each strategy accepts the following optional settings:
    The built-in `facebook` provider, for example, could have `fields` specified to determine the fields returned from the user's graph, which would
    then be available to you in the `auth.credentials.profile.raw` object.
 - `runtimeStateCallback` - allows passing additional OAuth state from initial request. This must be a function returning a string, which will be appended to the **bell** internal `state` parameter for OAuth code flow.
+- `agent` - Agent for `Wreck` requests.
 
 ### Advanced Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,8 @@ internals.schema = Joi.object({
     skipProfile: Joi.boolean().optional().default(false),
     forceHttps: Joi.boolean().optional().default(false),
     location: Joi.string().optional().default(false),
-    runtimeStateCallback: Joi.func().optional()
+    runtimeStateCallback: Joi.func().optional(),
+    agent: Joi.alternatives().try(Joi.object(), Joi.boolean()).optional()
 });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ internals.schema = Joi.object({
         token: Joi.string().required(),
         headers: Joi.object(),
         profile: Joi.func(),
+        profileMethod: Joi.string().valid('get', 'post').default('get'),
         scope: Joi.alternatives().try(
             Joi.array().items(Joi.string()),
             Joi.func()

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,8 +74,7 @@ internals.schema = Joi.object({
     skipProfile: Joi.boolean().optional().default(false),
     forceHttps: Joi.boolean().optional().default(false),
     location: Joi.string().optional().default(false),
-    runtimeStateCallback: Joi.func().optional(),
-    agent: Joi.alternatives().try(Joi.object(), Joi.boolean()).optional()
+    runtimeStateCallback: Joi.func().optional()
 });
 
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -229,10 +229,6 @@ exports.v2 = function (settings) {
             }
         };
 
-        if ('agent' in settings) {
-            requestOptions.agent = settings.agent;
-        }
-
         if (!settings.provider.useParamsAuth) {
             requestOptions.headers.Authorization = 'Basic ' + (new Buffer(settings.clientId + ':' + settings.clientSecret, 'utf8')).toString('base64');
         }
@@ -277,10 +273,6 @@ exports.v2 = function (settings) {
                         Authorization: 'Bearer ' + payload.access_token
                     }
                 };
-
-                if ('agent' in settings) {
-                    getOptions.agent = settings.agent;
-                }
 
                 if (settings.profileParams) {
                     Hoek.merge(params, settings.profileParams);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -229,6 +229,10 @@ exports.v2 = function (settings) {
             }
         };
 
+        if ('agent' in settings) {
+            requestOptions.agent = settings.agent;
+        }
+
         if (!settings.provider.useParamsAuth) {
             requestOptions.headers.Authorization = 'Basic ' + (new Buffer(settings.clientId + ':' + settings.clientSecret, 'utf8')).toString('base64');
         }
@@ -273,6 +277,10 @@ exports.v2 = function (settings) {
                         Authorization: 'Bearer ' + payload.access_token
                     }
                 };
+
+                if ('agent' in settings) {
+                    getOptions.agent = settings.agent;
+                }
 
                 if (settings.profileParams) {
                     Hoek.merge(params, settings.profileParams);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -283,7 +283,7 @@ exports.v2 = function (settings) {
                 }
 
                 const getQuery = (params ? '?' + internals.queryString(params) : '');
-                Wreck.get(uri + getQuery, getOptions, (err, res, response) => {
+                Wreck[settings.provider.profileMethod](uri + getQuery, getOptions, (err, res, response) => {
 
                     if (err ||
                         res.statusCode !== 200) {

--- a/lib/providers/dropbox-v2.js
+++ b/lib/providers/dropbox-v2.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports = module.exports = function (options) {
+
+    return {
+        protocol: 'oauth2',
+        useParamsAuth: true,
+        auth: 'https://www.dropbox.com/oauth2/authorize',
+        token: 'https://api.dropboxapi.com/oauth2/token',
+        profileMethod: 'post',
+        profile: function (credentials, params, post, callback) {
+
+            post('https://api.dropboxapi.com/2/users/get_current_account', null, (profile) => {
+
+                credentials.profile = profile;
+                return callback();
+            });
+        }
+    };
+};

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -4,6 +4,7 @@ exports = module.exports = {
     auth0: require('./auth0'),
     bitbucket: require('./bitbucket'),
     dropbox: require('./dropbox'),
+    dropboxV2: require('./dropbox-v2'),
     facebook: require('./facebook'),
     fitbit: require('./fitbit'),
     foursquare: require('./foursquare'),

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1503,6 +1503,60 @@ describe('Bell', () => {
             });
         });
 
+        it('allows wreck agent', (done) => {
+
+            const mock = new Mock.V2();
+            mock.start((provider) => {
+
+                const server = new Hapi.Server();
+                server.connection({ host: 'localhost', port: 80 });
+                server.register(Bell, (err) => {
+
+                    expect(err).to.not.exist();
+
+                    const custom = Bell.providers.facebook();
+                    Hoek.merge(custom, provider);
+
+                    server.auth.strategy('custom', 'bell', {
+                        password: 'cookie_encryption_password_secure',
+                        isSecure: false,
+                        clientId: 'facebook',
+                        clientSecret: 'secret',
+                        provider: custom,
+                        agent: false
+                    });
+
+                    server.route({
+                        method: '*',
+                        path: '/login',
+                        config: {
+                            auth: 'custom',
+                            handler: function (request, reply) {
+
+                                reply(request.auth.credentials);
+                            }
+                        }
+                    });
+
+                    server.inject('/login', (res) => {
+
+                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+
+                        mock.server.inject(res.headers.location, (mockRes) => {
+
+                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                                Mock.clear();
+                                expect(response.statusCode).to.equal(500);
+                                mock.stop(done);
+                            });
+                        });
+                    });
+
+                });
+            });
+        });
+
         it('fails on missing state', (done) => {
 
             const mock = new Mock.V2();

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -1503,60 +1503,6 @@ describe('Bell', () => {
             });
         });
 
-        it('allows wreck agent', (done) => {
-
-            const mock = new Mock.V2();
-            mock.start((provider) => {
-
-                const server = new Hapi.Server();
-                server.connection({ host: 'localhost', port: 80 });
-                server.register(Bell, (err) => {
-
-                    expect(err).to.not.exist();
-
-                    const custom = Bell.providers.facebook();
-                    Hoek.merge(custom, provider);
-
-                    server.auth.strategy('custom', 'bell', {
-                        password: 'cookie_encryption_password_secure',
-                        isSecure: false,
-                        clientId: 'facebook',
-                        clientSecret: 'secret',
-                        provider: custom,
-                        agent: false
-                    });
-
-                    server.route({
-                        method: '*',
-                        path: '/login',
-                        config: {
-                            auth: 'custom',
-                            handler: function (request, reply) {
-
-                                reply(request.auth.credentials);
-                            }
-                        }
-                    });
-
-                    server.inject('/login', (res) => {
-
-                        const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
-
-                        mock.server.inject(res.headers.location, (mockRes) => {
-
-                            server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
-
-                                Mock.clear();
-                                expect(response.statusCode).to.equal(500);
-                                mock.stop(done);
-                            });
-                        });
-                    });
-
-                });
-            });
-        });
-
         it('fails on missing state', (done) => {
 
             const mock = new Mock.V2();

--- a/test/providers/dropbox-v2.js
+++ b/test/providers/dropbox-v2.js
@@ -70,7 +70,7 @@ describe('dropbox-v2', () => {
                     const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
                     mock.server.inject(res.headers.location, (mockRes) => {
 
-                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+                        server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
 
                             Mock.clear();
                             expect(response.result).to.equal({
@@ -79,7 +79,7 @@ describe('dropbox-v2', () => {
                                 expiresIn: 3600,
                                 refreshToken: undefined,
                                 query: {},
-                                profile: profile
+                                profile
                             });
 
                             mock.stop(done);

--- a/test/providers/dropbox-v2.js
+++ b/test/providers/dropbox-v2.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Load modules
+
+const Bell = require('../../');
+const Code = require('code');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Mock = require('../mock');
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('dropbox-v2', () => {
+
+    it('authenticates with mock', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.dropboxV2();
+                Hoek.merge(custom, provider);
+
+                const profile = {
+                    display_name: '1234567890',
+                    username: 'steve',
+                    name: 'steve',
+                    first_name: 'steve',
+                    last_name: 'smith',
+                    email: 'steve@example.com'
+                };
+
+                Mock.override('https://api.dropboxapi.com/2/users/get_current_account', profile);
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'dropbox',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: profile
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
The existing Dropbox provider uses Dropbox API V1 which has been deprecated in April 2016. New API V2 uses "RPC" style calls (i.e. POST) for requesting user account information. So far all providers are requesting account information by GET calls. There is a new provider config option now ("providerMethod") which can be set to 'post' in order to get account information by POST request (defaults to 'get').

[https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account](https://www.dropbox.com/developers/documentation/http/documentation#users-get_current_account)
