### PR TITLE
Add discord as a new provider

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -86,6 +86,33 @@ credentials.profile = {
 };
 ```
 
+### Discord
+
+[Provider Documentation](https://discordapp.com/developers/docs/topics/oauth2)
+
+- `scope`: Defaults to `['email', 'identify']`
+- `config`: not applicable
+- `auth`: ttps://discordapp.com/api/oauth2/authorize
+- `token`: https://discordapp.com/api/oauth2/token
+
+The default profile response will look like this:
+
+```javascript
+credentials.profile = {
+    id: parseInt(profile.id),
+    discriminator: parseInt(profile.discriminator),
+    username: profile.username,
+    email: profile.email,
+    mfa_enabled: profile.mfa_enabled,
+    verified: profile.verified,
+    avatar: {
+        id: profile.avatar,
+        url: 'https://discordapp.com/api/users/' + profile.id + '/avatars/' + profile.avatar + '.jpg'
+    },
+    raw: profile
+};
+```
+
 ### Dropbox
 
 [Provider Documentation](https://www.dropbox.com/developers/core/docs)

--- a/Providers.md
+++ b/Providers.md
@@ -92,15 +92,15 @@ credentials.profile = {
 
 - `scope`: Defaults to `['email', 'identify']`
 - `config`: not applicable
-- `auth`: ttps://discordapp.com/api/oauth2/authorize
+- `auth`: https://discordapp.com/api/oauth2/authorize
 - `token`: https://discordapp.com/api/oauth2/token
 
 The default profile response will look like this:
 
 ```javascript
 credentials.profile = {
-    id: parseInt(profile.id),
-    discriminator: parseInt(profile.discriminator),
+    id: profile.id,
+    discriminator: profile.discriminator,
     username: profile.username,
     email: profile.email,
     mfa_enabled: profile.mfa_enabled,

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lead Maintainer: [Lois Desplat](https://github.com/ldesplat)
 
 [![Build Status](https://secure.travis-ci.org/hapijs/bell.png)](http://travis-ci.org/hapijs/bell)
 
-**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Google Plus`, `Instagram`, `LinkedIn`, `Slack`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch`, `Salesforce` and `Pinterest`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
+**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Google Plus`, `Instagram`, `LinkedIn`, `Slack`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch`, `Salesforce`, `Pinterest` and `Discord`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
 
 ## Documentation
 

--- a/examples/discord.js
+++ b/examples/discord.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// Load modules
+
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Bell = require('../');
+
+
+const server = new Hapi.Server();
+server.connection({ port: 8000 });
+
+server.register(Bell, (err) => {
+
+    Hoek.assert(!err, err);
+    server.auth.strategy('discord', 'bell', {
+        provider: 'discord',
+        password: 'cookie_encryption_password_secure',
+        isSecure: false,
+        // Fill in your clientId and clientSecret: https://discordapp.com/developers/applications/me
+        clientId: '',
+        clientSecret: ''
+    });
+
+    server.route({
+        method: '*',
+        path: '/bell/door',
+        config: {
+            auth: 'discord',
+            handler: function (request, reply) {
+
+                reply('<pre>' + JSON.stringify(request.auth.credentials, null, 4) + '</pre>');
+            }
+        }
+    });
+
+    server.start((err) => {
+
+        Hoek.assert(!err, err);
+        console.log('Server started at:', server.info.uri);
+    });
+});

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -10,6 +10,7 @@ exports = module.exports = function () {
         profile: function (credentials, params, get, callback) {
 
             get('https://discordapp.com/api/users/@me', null, (profile) => {
+
                 credentials.profile = {
                     id: profile.id,
                     discriminator: profile.discriminator,

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -10,10 +10,9 @@ exports = module.exports = function () {
         profile: function (credentials, params, get, callback) {
 
             get('https://discordapp.com/api/users/@me', null, (profile) => {
-
                 credentials.profile = {
-                    id: parseInt(profile.id),
-                    discriminator: parseInt(profile.discriminator),
+                    id: profile.id,
+                    discriminator: profile.discriminator,
                     username: profile.username,
                     email: profile.email,
                     mfa_enabled: profile.mfa_enabled,

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports = module.exports = function () {
+
+    return {
+        protocol: 'oauth2',
+        auth: 'https://discordapp.com/api/oauth2/authorize',
+        token: 'https://discordapp.com/api/oauth2/token',
+        scope: ['email', 'identify'], // see https://discordapp.com/developers/docs/topics/oauth2#scopes
+        profile: function (credentials, params, get, callback) {
+
+            get('https://discordapp.com/api/users/@me', null, (profile) => {
+
+                credentials.profile = {
+                    id: parseInt(profile.id),
+                    discriminator: parseInt(profile.discriminator),
+                    username: profile.username,
+                    email: profile.email,
+                    mfa_enabled: profile.mfa_enabled,
+                    verified: profile.verified,
+                    avatar: {
+                        id: profile.avatar,
+                        url: 'https://discordapp.com/api/users/' + profile.id + '/avatars/' + profile.avatar + '.jpg'
+                    },
+                    raw: profile
+                };
+
+                return callback();
+            });
+        }
+    };
+};

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -29,5 +29,6 @@ exports = module.exports = {
     wordpress: require('./wordpress'),
     office365: require('./office365'),
     pinterest: require('./pinterest'),
-    pingfed: require('./pingfed')
+    pingfed: require('./pingfed'),
+    discord: require('./discord')
 };

--- a/test/providers/discord.js
+++ b/test/providers/discord.js
@@ -79,9 +79,9 @@ describe('discord', () => {
                                 expiresIn: 3600,
                                 query: {},
                                 profile: {
-                                    id: 80351110224678912,
+                                    id: '80351110224678912',
                                     username: 'Nelly',
-                                    discriminator: 1337,
+                                    discriminator: '1337',
                                     mfa_enabled: false,
                                     avatar: {
                                         id: '8342729096ea3675442027381ff50dfe',

--- a/test/providers/discord.js
+++ b/test/providers/discord.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Load modules
+
+const Bell = require('../../');
+const Code = require('code');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Mock = require('../mock');
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('discord', () => {
+
+    it('authenticates with mock', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.discord();
+                Hoek.merge(custom, provider);
+
+                Mock.override('https://discordapp.com/api/users/@me', {
+                    id: '80351110224678912',
+                    username: 'Nelly',
+                    discriminator: '1337',
+                    mfa_enabled: false,
+                    avatar: '8342729096ea3675442027381ff50dfe',
+                    verified: true,
+                    email: 'nelly@discordapp.com'
+                });
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'discord',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: '456',
+                                refreshToken: undefined,
+                                expiresIn: 3600,
+                                query: {},
+                                profile: {
+                                    id: 80351110224678912,
+                                    username: 'Nelly',
+                                    discriminator: 1337,
+                                    mfa_enabled: false,
+                                    avatar: {
+                                        id: '8342729096ea3675442027381ff50dfe',
+                                        url: 'https://discordapp.com/api/users/80351110224678912/avatars/8342729096ea3675442027381ff50dfe.jpg'
+                                    },
+                                    verified: true,
+                                    email: 'nelly@discordapp.com',
+                                    raw: {
+                                        id: '80351110224678912',
+                                        username: 'Nelly',
+                                        discriminator: '1337',
+                                        mfa_enabled: false,
+                                        avatar: '8342729096ea3675442027381ff50dfe',
+                                        verified: true,
+                                        email: 'nelly@discordapp.com'
+                                    }
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
I added discord ([https://discordapp.com/developers/docs/topics/oauth2](https://discordapp.com/developers/docs/topics/oauth2)) as a new provider for bell. I'm working on a project which needs the ability to login with discord.

The tests are working & the code coverage is still 100%, here's a pastebin for the test results: [http://pastebin.com/CA7GnBdV](http://pastebin.com/CA7GnBdV).

The documentation of the provider was added to the `Providers.md` file as well.

Let me know if there's something missing.