### PR TITLE
Twitter additional GET parameters on extended profile request

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -466,6 +466,7 @@ credentials.profile = {
 - `config`:
   - `extendedProfile`: Request for more profile information
   - `getMethod`: [Twitter API](https://dev.twitter.com/rest/public) GET method to call when `extendedProfile` is enabled. Defaults to `'users/show'`
+  - `getParams`: Additional parameters to pass to the GET method. For example, the `include_email` parameter for the [`account/verify` route](https://dev.twitter.com/rest/reference/get/account/verify_credentials)
 - `temporary`: 'https://api.twitter.com/oauth/request_token'
 - `auth`: https://api.twitter.com/oauth/authenticate
 - `token`: https://api.twitter.com/oauth/access_token

--- a/lib/providers/twitter.js
+++ b/lib/providers/twitter.js
@@ -30,7 +30,7 @@ exports = module.exports = function (options) {
             const paramDefaults = {
                 user_id: params.user_id
             };
-            const getParams = Hoek.applyToDefaults(paramDefaults, settings.getParams);
+            const getParams = Hoek.applyToDefaults(paramDefaults, settings.getParams || {});
 
             get(`https://api.twitter.com/1.1/${settings.getMethod}.json`, getParams, (profile) => {
 

--- a/lib/providers/twitter.js
+++ b/lib/providers/twitter.js
@@ -27,7 +27,12 @@ exports = module.exports = function (options) {
                 return callback();
             }
 
-            get(`https://api.twitter.com/1.1/${settings.getMethod}.json`, { user_id: params.user_id }, (profile) => {
+            const paramDefaults = {
+                user_id: params.user_id
+            };
+            const getParams = Hoek.applyToDefaults(paramDefaults, settings.getParams);
+
+            get(`https://api.twitter.com/1.1/${settings.getMethod}.json`, getParams, (profile) => {
 
                 credentials.profile.displayName = profile.name;
                 credentials.profile.raw = profile;

--- a/test/providers/twitter.js
+++ b/test/providers/twitter.js
@@ -158,6 +158,81 @@ describe('twitter', () => {
         });
     });
 
+    it('authenticates with mock and custom method with custom GET parameters', { parallel: false }, (done) => {
+
+        const mock = new Mock.V1();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.twitter({
+                    getMethod: 'custom/method',
+                    getParams: {
+                        param1: 'custom',
+                        param2: 'params'
+                    }
+                });
+                Hoek.merge(custom, provider);
+
+                Mock.override('https://api.twitter.com/1.1/custom/method.json', {
+                    property: 'something'
+                });
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'twitter',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie: cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: 'final',
+                                secret: 'secret',
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    username: 'Steve Stevens',
+                                    displayName: undefined,
+                                    raw: {
+                                        property: 'something'
+                                    }
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     it('authenticates with mock (without extended profile)', { parallel: false }, (done) => {
 
         const mock = new Mock.V1();


### PR DESCRIPTION
I was trying to retrieve the email of Twitter users and found it on [this API route](https://dev.twitter.com/rest/reference/get/account/verify_credentials). However, fetching the email from this route requires an additional GET parameter. This PR allows for additional parameters to that extended profile call.

Questions I have:

1. When writing the test for this option, I couldn't find a way in the Mock'd Twitter endpoint to verify if there were actual GET parameters passed to that route. Is this something that's testable?

2. Should dynamic GET parameters (via a function in the config) be allowed? In my use case, I only needed to add `"include_email": "true"`, but other parameters might be dependent on the authenticated user's information.

Thanks!