### PR TITLE
adds to option to collect bot credentials from Slack

### DIFF
--- a/lib/providers/slack.js
+++ b/lib/providers/slack.js
@@ -17,6 +17,15 @@ exports = module.exports = function slackProvider(options) {
                 access_token: params.access_token,
                 scope: params.scope
             };
+
+            // If a 'bot' scope is requested, add the bot user id and token
+            if (params.bot){
+                credentials.profile.bot = {
+                    bot_user_id: params.bot.bot_user_id,
+                    bot_access_token: params.bot.bot_access_token
+                };
+            }
+                        
             // If `extendedProfile` is set to `false`, just return immediately.
             // `access_token` on `credentials.profile` can now be used to call Slack methods.
             if (options.extendedProfile === false) {


### PR DESCRIPTION
Hi, this is tiny addition helps with getting the bot user id and token from Slack when providing the 'bot' scope. These credentials are in the first reply of Slack and not on the auth/test endpoint. I think this is neater than doing another request to grab these credentials. 

Unfortunately, I haven't found a way to test this cleanly. Trigger the behaviour is done by adding the scope:

```
scope: ['bot']
```

Slack response with a payload similar to the following. Note the nest `bot` object.

```json
{"ok":true,"access_token":"xoxp-ABCD","scope":"identify,bot","user_id":"U12345","team_name":"myteam","team_id":"TABCD","bot":{"bot_user_id":"U1234","bot_access_token":"xoxb-ABCD"}}
```


