### PR TITLE
allow for leading whitespace in JSON

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -558,7 +558,7 @@ internals.encode = function (string) {
 internals.parse = function (payload) {
 
     payload = Buffer.isBuffer(payload) ? payload.toString() : payload;
-    if (payload[0] === '{') {
+    if (payload.trim()[0] === '{') {
         try {
             return JSON.parse(payload);
         }


### PR DESCRIPTION
Some oauth providers (specifically AT&T) return their JSON payloads with lots of leading whitespace, which fails the current test of `payload[0] === '{'` and causes the response from `get` to be passed through `Querystring.parse` instead.

This PR is an attempt to allow for situations like this, and still properly catch these payloads as JSON.

I tried looking through the tests to see where I could add a case to ensure this works but didn't see anywhere that stood out to me. I'm more than happy to attempt that if given a little more direction on this.