### PR TITLE
Set isSameSite to false and add code to support Hapi 13.5+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,6 +105,7 @@ internals.implementation = function (server, options) {
         password: settings.password,
         isSecure: settings.isSecure !== false,                  // Defaults to true
         isHttpOnly: settings.isHttpOnly !== false,              // Defaults to true
+        isSameSite: false,
         ttl: settings.ttl,
         domain: settings.domain,
         ignoreErrors: true,
@@ -112,7 +113,19 @@ internals.implementation = function (server, options) {
     };
 
     settings.cookie = settings.cookie || 'bell-' + settings.name;
-    server.state(settings.cookie, cookieOptions);
+    try {
+        server.state(settings.cookie, cookieOptions);
+    }
+    catch (exception) {
+        /* $lab:coverage:off$ */
+        // This is to support Hapi 13.5.0 so that adding isSameSite: false option is not a breaking change
+        if (exception.message.indexOf('isSameSite') === -1) {
+            throw exception;
+        }
+        delete cookieOptions.isSameSite;
+        server.state(settings.cookie, cookieOptions);
+        /* $lab:coverage:on$ */
+    }
 
     if (internals.simulate) {
         return internals.simulated(settings);


### PR DESCRIPTION
Resolves #264 in a non-breaking manner.

Had to turn off code coverage for the Hapi 13 support, due to multiple reasons:
1. Don't want to run code coverage using hapi 13
2. Hapi 14 and up, don't error on server.state with cookie passwords less than 32 characters like Hapi 13 did so I don't know how to force an error here either.
3. The way Hapi is implemented makes it hard to stub out the server.state method to force those scenarios.

Plan is to remove this code in next breaking release and stop support for Hapi 13 at that time.