### PR TITLE
Fixes #261 expose OAUTH2 token response as request.auth.artifacts

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -262,7 +262,7 @@ exports.v2 = function (settings) {
             };
 
             if (!settings.provider.profile || settings.skipProfile) {
-                return reply.continue({ credentials });
+                return reply.continue({ credentials, artifacts: payload });
             }
 
             // Obtain user profile
@@ -303,7 +303,7 @@ exports.v2 = function (settings) {
 
             settings.provider.profile.call(settings, credentials, payload, get, () => {
 
-                return reply.continue({ credentials });
+                return reply.continue({ credentials, artifacts: payload });
             });
         });
     };

--- a/test/providers/auth0.js
+++ b/test/providers/auth0.js
@@ -80,7 +80,7 @@ describe('auth0', () => {
                         auth: 'custom',
                         handler: function (request, reply) {
 
-                            reply(request.auth.credentials);
+                            reply(request.auth);
                         }
                     }
                 });
@@ -93,7 +93,7 @@ describe('auth0', () => {
                         server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
 
                             Mock.clear();
-                            expect(response.result).to.equal({
+                            expect(response.result.credentials).to.equal({
                                 provider: 'custom',
                                 token: '456',
                                 expiresIn: 3600,
@@ -110,7 +110,10 @@ describe('auth0', () => {
                                     raw: profile
                                 }
                             });
-
+                            expect(response.result.artifacts).to.equal({
+                                'access_token': '456',
+                                'expires_in': 3600
+                            });
                             mock.stop(done);
                         });
                     });


### PR DESCRIPTION
OpenId Connect providers return an ID token in the `id_token` property of
their `token` response, e.g. `auth0` with `scope: ['openid']`. This
change caters for any scenario requiring unexpected properties from the
`token` response by exposing the full `token` payload as
`request.auth.artifacts`.
