### PR TITLE
Add link to all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Lead Maintainer: [Lois Desplat](https://github.com/ldesplat)
 
 [**Social Login with Twitter using hapi.js**](http://mph-web.de/social-signup-with-twitter-using-hapi-js/)
 
-## Example
+## Examples
+
+[**All Examples**](/examples)
+
+Twitter:
 
 ```javascript
 var Hapi = require('hapi');


### PR DESCRIPTION
I originally missed the `examples` directory and thought it'd be nice to link to in the README.