### PR TITLE
AzureAD: Support email, when userPrincipalName (upn) is not available

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -82,7 +82,7 @@ The default response would look like this in the `profile` object obtained
 credentials.profile = {
     id: profile.oid,
     displayName: profile.name,
-    email: profile.upn,
+    email: profile.upn || profile.email,
     raw: profile
 };
 ```

--- a/lib/providers/azuread.js
+++ b/lib/providers/azuread.js
@@ -18,7 +18,7 @@ exports = module.exports = function (options) {
                 credentials.profile = {
                     id: profile.oid,
                     displayName: profile.name,
-                    email: profile.upn,
+                    email: profile.upn || profile.email,
                     raw: profile
                 };
                 return reply();

--- a/test/providers/azuread.js
+++ b/test/providers/azuread.js
@@ -17,77 +17,117 @@ const describe = lab.describe;
 const it = lab.it;
 const expect = Code.expect;
 
+
+// Test helpers
+
+const testProfile = function (opts) {
+
+    const profile = opts.profile;
+    const expectedResult = opts.expectedResult;
+    const done = opts.done;
+    const mock = new Mock.V2();
+    mock.start((provider) => {
+
+        const server = new Hapi.Server();
+        server.connection({ host: 'localhost', port: 80 });
+        server.register(Bell, (err) => {
+
+            expect(err).to.not.exist();
+
+            const custom = Bell.providers.azuread();
+            Hoek.merge(custom, provider);
+
+            Mock.override('https://login.microsoftonline.com/common/openid/userinfo', profile);
+
+            server.auth.strategy('custom', 'bell', {
+                password: 'cookie_encryption_password_secure',
+                isSecure: false,
+                clientId: 'azuread',
+                clientSecret: 'secret',
+                provider: custom
+            });
+
+            server.route({
+                method: '*',
+                path: '/login',
+                config: {
+                    auth: 'custom',
+                    handler: function (request, reply) {
+
+                        reply(request.auth.credentials);
+                    }
+                }
+            });
+
+            server.inject('/login', (res) => {
+
+                const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                mock.server.inject(res.headers.location, (mockRes) => {
+
+                    server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
+
+                        Mock.clear();
+                        expect(response.result).to.equal(expectedResult);
+
+                        mock.stop(done);
+                    });
+                });
+            });
+        });
+    });
+};
+
 describe('azuread', () => {
 
     it('authenticates with mock Azure AD', { parallel: false }, (done) => {
 
-        const mock = new Mock.V2();
-        mock.start((provider) => {
+        const profile = {
+            oid: '1234567890',
+            name: 'Sample AD User',
+            upn: 'sample@microsoft.com'
+        };
+        testProfile({
+            profile,
+            expectedResult: {
+                provider: 'custom',
+                token: '456',
+                expiresIn: 3600,
+                refreshToken: undefined,
+                query: {},
+                profile: {
+                    id: '1234567890',
+                    displayName: 'Sample AD User',
+                    email: 'sample@microsoft.com',
+                    raw: profile
+                }
+            },
+            done
+        });
+    });
 
-            const server = new Hapi.Server();
-            server.connection({ host: 'localhost', port: 80 });
-            server.register(Bell, (err) => {
+    it('authenticates with mock Azure AD email', { parallel: false }, (done) => {
 
-                expect(err).to.not.exist();
-
-                const custom = Bell.providers.azuread();
-                Hoek.merge(custom, provider);
-
-                const profile = {
-                    oid: '1234567890',
-                    name: 'Sample AD User',
-                    upn: 'sample@microsoft.com'
-                };
-
-                Mock.override('https://login.microsoftonline.com/common/openid/userinfo', profile);
-
-                server.auth.strategy('custom', 'bell', {
-                    password: 'cookie_encryption_password_secure',
-                    isSecure: false,
-                    clientId: 'azuread',
-                    clientSecret: 'secret',
-                    provider: custom
-                });
-
-                server.route({
-                    method: '*',
-                    path: '/login',
-                    config: {
-                        auth: 'custom',
-                        handler: function (request, reply) {
-
-                            reply(request.auth.credentials);
-                        }
-                    }
-                });
-
-                server.inject('/login', (res) => {
-
-                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
-                    mock.server.inject(res.headers.location, (mockRes) => {
-
-                        server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
-
-                            Mock.clear();
-                            expect(response.result).to.equal({
-                                provider: 'custom',
-                                token: '456',
-                                expiresIn: 3600,
-                                refreshToken: undefined,
-                                query: {},
-                                profile: {
-                                    id: '1234567890',
-                                    displayName: 'Sample AD User',
-                                    email: 'sample@microsoft.com',
-                                    raw: profile
-                                }
-                            });
-
-                            mock.stop(done);
-                        });
-                    });
-                });
-            });
+        const profile = {
+            oid: '1234567890',
+            name: 'Sample AD User',
+            email: 'sample@microsoft.com'
+        };
+        testProfile({
+            profile,
+            expectedResult: {
+                provider: 'custom',
+                token: '456',
+                expiresIn: 3600,
+                refreshToken: undefined,
+                query: {},
+                profile: {
+                    id: '1234567890',
+                    displayName: 'Sample AD User',
+                    email: 'sample@microsoft.com',
+                    raw: profile
+                }
+            },
+            done
         });
     });
 


### PR DESCRIPTION
Support the email field, when `userPrincipalName` is not available.

From the Azure Active Directory graph API documentation about `userPrincipalName` (`upn`):

> This property is required when a work or school account is created; it is optional for local accounts. 

https://msdn.microsoft.com/en-us/library/azure/ad/graph/api/entity-and-complex-type-reference#contact-entity

When `upn` is not available, `profile.email` stores the email, so fall back on this value.

Have tested on an account created from live.com, where the `email` value exists there, but not `upn`.