### PR TITLE
Add `'profile'` to list of default scopes for Okta

### DIFF
--- a/lib/providers/okta.js
+++ b/lib/providers/okta.js
@@ -23,7 +23,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: settings.uri + '/oauth2/v1/authorize',
         token: settings.uri + '/oauth2/v1/token',
-        scope: ['openid', 'email', 'offline_access'],
+        scope: ['profile', 'openid', 'email', 'offline_access'],
         profile: function (credentials, params, get, callback) {
 
             get(settings.uri + '/oauth2/v1/userinfo', null, (profile) => {


### PR DESCRIPTION
The overwhelming majority of use cases for Okta will need profile information. It was an oversight on my part to not add this originally here: https://github.com/hapijs/bell/pull/299.