### PR TITLE
Add support for Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,10 @@
 # How to contribute
+
 We welcome contributions from the community and are pleased to have them.
 Please follow this guide when logging issues or making code changes.
 
 ## Logging Issues
+
 All issues should be created using the
 [new issue form](https://github.com/hapijs/bell/issues/new). Clearly describe
 the issue including steps to reproduce if there are any. Also, make sure to
@@ -17,6 +19,7 @@ Code changes are welcome and should follow the guidelines below.
   [style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
 * Add tests for your new code ensuring that you have 100% code coverage
   (we can help you reach 100% but will not merge without it).
-* Run `npm test` to generate a report of test coverage
+* Run `npm test` to generate a report of test coverage.  Alternatively
+  run `npm run test-docker` to build and run the test suite in a Docker container.
 * [Pull requests](http://help.github.com/send-pull-requests/) should be
   made to the [master branch](https://github.com/hapijs/bell/tree/master).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:4.8.2
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ENV NODE_ENV development
+
+EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+dev:
+  build: .
+  dockerfile: Dockerfile
+  ports:
+    - "3000:3000"
+  volumes:
+    - ".:/usr/src/app"
+  volumes_from:
+    - node-modules
+
+# Why am I using the same image for both `dev` and `node-modules`?
+# See here: http://container42.com/2014/11/18/data-only-container-madness/
+# TL;DR It sets file permissions correctly and saves a lot of space
+node-modules:
+  image: node:4.8.2
+  entrypoint: '/bin/echo node_modules data-only container for dev'
+  volumes:
+    - "/usr/src/app/node_modules"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "scripts": {
     "test": "node node_modules/lab/bin/lab -t 100 -L -v",
+    "test-docker": "docker-compose run dev npm install && docker-compose run dev node_modules/lab/bin/lab -t 100 -L -v",
     "test-cov-html": "node node_modules/lab/bin/lab -r html -o coverage.html -L"
   },
   "license": "BSD-3-Clause"


### PR DESCRIPTION
Previously running the test suite required you to install `node_modules` locally and configure your local environment.  This commit adds a `Dockerfile` and a `docker-compose.yml` for those who wish to run the test suite and develop in a Docker container.