### PR TITLE
Add `fields` option to Facebook provider

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -176,7 +176,8 @@ The default profile response will look like this:
 [Provider Documentation](https://developers.facebook.com/docs/facebook-login/access-tokens)
 
 - `scope`: Defaults to `['email']`
-- `config`: not applicable
+- `config`:
+  - `fields`: List of profile fields to retrieve, as described in [Facebook's documentation](https://developers.facebook.com/docs/graph-api/reference/user). Defaults to `'id,name,email,first_name,last_name,middle_name,gender,link,locale,timezone,updated_time,verified'`.
 - `auth`: https://www.facebook.com/v2.3/dialog/oauth
 - `token`: https://graph.facebook.com/v2.3/oauth/access_token
 

--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -3,9 +3,15 @@
 // Load modules
 
 const Crypto = require('crypto');
+const Hoek = require('hoek');
 
 
 exports = module.exports = function (options) {
+
+    const defaults = {
+        fields: 'id,name,email,first_name,last_name,middle_name,gender,link,locale,timezone,updated_time,verified'
+    };
+    const settings = Hoek.applyToDefaults(defaults, options || {});
 
     return {
         protocol: 'oauth2',
@@ -18,7 +24,7 @@ exports = module.exports = function (options) {
 
             const query = {
                 appsecret_proof: Crypto.createHmac('sha256', this.clientSecret).update(credentials.token).digest('hex'),
-                fields: 'id,name,email,first_name,last_name,middle_name,gender,link,locale,timezone,updated_time,verified'
+                fields: settings.fields
             };
 
             get('https://graph.facebook.com/v2.9/me', query, (profile) => {

--- a/test/providers/facebook.js
+++ b/test/providers/facebook.js
@@ -99,4 +99,91 @@ describe('facebook', () => {
             });
         });
     });
+
+    it('authenticates with mock (with custom fields)', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.facebook({ fields: 'id,name,email,first_name,last_name,middle_name,picture' });
+                Hoek.merge(custom, provider);
+
+                const profile = {
+                    id: '1234567890',
+                    username: 'steve',
+                    name: 'steve',
+                    first_name: 'steve',
+                    last_name: 'smith',
+                    email: 'steve@example.com',
+                    picture: {
+                        data: {
+                            is_silhouette: false,
+                            url: 'https://example.com/profile.png'
+                        }
+                    }
+                };
+
+                Mock.override('https://graph.facebook.com/v2.9/me', profile);
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'facebook',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: {
+                                    id: '1234567890',
+                                    username: 'steve',
+                                    displayName: 'steve',
+                                    name: {
+                                        first: 'steve',
+                                        last: 'smith',
+                                        middle: undefined
+                                    },
+                                    email: 'steve@example.com',
+                                    raw: profile
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This commit adds a new option (and the first) configuration option
to the Facebook provider: `fields`, which allows to request
additional profile fields if needed.

This should be a non-breaking change, as the `fields` option has a
default value.

Fix #297