### PR TITLE
Add Stripe as a new provider

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -698,6 +698,27 @@ credentials.profile = {
 };
 ```
 
+### Stripe
+
+[Provider Documentation](https://stripe.com/docs/connect/oauth-reference)
+
+- `scope`: defaults to `read_only` scope
+- `config`: not applicable
+- `auth`: https://connect.stripe.com/oauth/authorize
+- `token`: https://connect.stripe.com/oauth/token
+
+The default profile response will look like this:
+
+```javascript
+credentials.profile = {
+    id: profile.id,
+    legalName: profile.business_name,
+    displayName: profile.display_name,
+    email: profile.email,
+    raw: profile
+};
+```
+
 ### Office 365
 
 [Provider Documentation](https://msdn.microsoft.com/en-us/library/azure/dn645545.aspx)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lead Maintainer: [Lois Desplat](https://github.com/ldesplat)
 
 [![Build Status](https://secure.travis-ci.org/hapijs/bell.png)](http://travis-ci.org/hapijs/bell)
 
-**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Google Plus`, `Instagram`, `LinkedIn`, `Slack`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch`, `Salesforce`, `Pinterest`, `Discord`, `DigitalOcean`, and `Okta`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
+**bell** ships with built-in support for authentication using `Facebook`, `GitHub`, `Google`, `Google Plus`, `Instagram`, `LinkedIn`, `Slack`, `Stripe`, `Twitter`, `Yahoo`, `Foursquare`, `VK`, `ArcGIS Online`, `Windows Live`, `Nest`, `Phabricator`, `BitBucket`, `Dropbox`, `Reddit`, `Tumblr`, `Twitch`, `Salesforce`, `Pinterest`, `Discord`, `DigitalOcean`, and `Okta`. It also supports any compliant `OAuth 1.0a` and `OAuth 2.0` based login services with a simple configuration object.
 
 ## Documentation
 

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -30,6 +30,7 @@ exports = module.exports = {
     salesforce: require('./salesforce'),
     slack: require('./slack'),
     spotify: require('./spotify'),
+    stripe: require('./stripe'),
     tumblr: require('./tumblr'),
     twitch: require('./twitch'),
     twitter: require('./twitter'),

--- a/lib/providers/stripe.js
+++ b/lib/providers/stripe.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports = module.exports = () => {
+
+    const domain = 'connect.stripe.com';
+
+    return {
+        protocol: 'oauth2',
+        useParamsAuth: true,
+        auth: `https://${domain}/oauth/authorize`,
+        token: `https://${domain}/oauth/token`,
+        scope: ['read_only'],
+        headers: { 'User-Agent': 'hapi-bell-stripe' },
+        profile: function (credentials, params, get, callback) {
+
+            const user = `https://${credentials.token}@${domain}/v1/account`;
+
+            get(user, null, (profile) => {
+
+                credentials.profile = {
+                    id: profile.id,
+                    legalName: profile.business_name,
+                    displayName: profile.display_name,
+                    email: profile.email,
+                    raw: profile
+                };
+
+                return callback();
+            });
+        }
+    };
+};

--- a/test/providers/stripe.js
+++ b/test/providers/stripe.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// Load modules
+
+const Bell = require('../../');
+const Code = require('code');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Mock = require('../mock');
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('stripe', () => {
+
+    it('authenticates with mock', { parallel: false }, (done) => {
+
+        const mock = new Mock.V2();
+        mock.start((provider) => {
+
+            const server = new Hapi.Server();
+            server.connection({ host: 'localhost', port: 80 });
+            server.register(Bell, (err) => {
+
+                expect(err).to.not.exist();
+
+                const custom = Bell.providers.stripe();
+                Hoek.merge(custom, provider);
+
+                const profile = {
+                    id: '1234',
+                    email: 'foo@example.com',
+                    business_name: 'Acme, Inc.',
+                    display_name: 'ACME Corp'
+                };
+
+                Mock.override('https://456@connect.stripe.com/v1/account', profile);
+
+                server.auth.strategy('custom', 'bell', {
+                    password: 'cookie_encryption_password_secure',
+                    isSecure: false,
+                    clientId: 'stripe',
+                    clientSecret: 'secret',
+                    provider: custom
+                });
+
+                server.route({
+                    method: '*',
+                    path: '/login',
+                    config: {
+                        auth: 'custom',
+                        handler: function (request, reply) {
+
+                            reply(request.auth.credentials);
+                        }
+                    }
+                });
+
+                server.inject('/login', (res) => {
+
+                    const cookie = res.headers['set-cookie'][0].split(';')[0] + ';';
+                    mock.server.inject(res.headers.location, (mockRes) => {
+
+                        server.inject({ url: mockRes.headers.location, headers: { cookie } }, (response) => {
+
+                            Mock.clear();
+                            expect(response.result).to.equal({
+                                provider: 'custom',
+                                token: '456',
+                                expiresIn: 3600,
+                                refreshToken: undefined,
+                                query: {},
+                                profile: {
+                                    id: '1234',
+                                    email: 'foo@example.com',
+                                    legalName: 'Acme, Inc.',
+                                    displayName: 'ACME Corp',
+                                    raw: profile
+                                }
+                            });
+
+                            mock.stop(done);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Time to make some $$$, yo.

This PR adds [Stripe](https://stripe.com), one of the most popular payment platforms, as a new provider. With this, we can use [Stripe Connect](https://stripe.com/connect) to help sellers sign up or log in to our platform and earn a living.

Stripe OAuth docs: https://stripe.com/docs/connect/oauth-reference