### PR TITLE
Allowing the location option to be a function

### DIFF
--- a/API.md
+++ b/API.md
@@ -100,7 +100,7 @@ The `server.auth.strategy()` method requires the following strategy options:
 - `clientId` - the OAuth client identifier (consumer key).
 - `clientSecret` - the OAuth client secret (consumer secret).
 - `forceHttps` - A boolean indicating whether or not you want the redirect_uri to be forced to https. Useful if your hapi application runs as http, but is accessed through https.
-- `location` - Set the base redirect_uri manually if it cannot be inferred properly from server settings. Useful to override port, protocol, and host if proxied or forwarded.
+- `location` - Set the base redirect_uri manually if it cannot be inferred properly from server settings. Useful to override port, protocol, and host if proxied or forwarded. It may be passed either as a string (in which case request.path is appended for you), or a function which takes the client's `request` and returns a non-empty string, which is used as provided. In both cases, an empty string will result in default processing just as if the `location` option had not been specified.
 
 Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to `'bell-provider'` where 'provider' is the provider name

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,10 @@ internals.schema = Joi.object({
     profileParams: Joi.object(),
     skipProfile: internals.flexBoolean.optional().default(false),
     forceHttps: internals.flexBoolean.optional().default(false),
-    location: Joi.string().optional().default(false),
+    location: Joi.alternatives().try(
+      Joi.func().maxArity(1),
+      Joi.string().optional().default(false)
+    ),
     runtimeStateCallback: Joi.func().optional()
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,8 +75,8 @@ internals.schema = Joi.object({
     forceHttps: internals.flexBoolean.optional().default(false),
     location: Joi.alternatives().try(
       Joi.func().maxArity(1),
-      Joi.string().optional().default(false)
-    ),
+      Joi.string()
+    ).default(false),
     runtimeStateCallback: Joi.func().optional()
 });
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -575,7 +575,7 @@ internals.parse = function (payload) {
 internals.location = function (request, protocol, location) {
 
     if (typeof location === 'function') {
-        return location(request);
+        return location(request) || internals.location(request, protocol);
     }
     if (location) {
         return location + request.path;
@@ -630,12 +630,10 @@ internals.getProtocol = (request, settings) => {
         return 'https';
     }
     const location = internals.location(request, request.connection.info.protocol, settings.location);
-    if (location && location.indexOf('https:') !== -1) {
+    if (location.indexOf('https:') !== -1) {
         return 'https';
     }
     return request.connection.info.protocol;
-
-
 };
 
 internals.resolveProviderParams = (request, params) => {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -574,6 +574,9 @@ internals.parse = function (payload) {
 
 internals.location = function (request, protocol, location) {
 
+    if (typeof location === 'function') {
+        return location(request);
+    }
     if (location) {
         return location + request.path;
     }
@@ -623,10 +626,16 @@ internals.Client.queryString = internals.queryString = function (params) {
 
 internals.getProtocol = (request, settings) => {
 
-    return settings.forceHttps ? 'https' : (
-        settings.location &&
-        settings.location.indexOf('https:') !== -1
-    ) ? 'https' : request.connection.info.protocol;
+    if (settings.forceHttps) {
+        return 'https';
+    }
+    const location = internals.location(request, request.connection.info.protocol, settings.location);
+    if (location && location.indexOf('https:') !== -1) {
+        return 'https';
+    }
+    return request.connection.info.protocol;
+
+
 };
 
 internals.resolveProviderParams = (request, params) => {


### PR DESCRIPTION
Addresses some of the need described in https://github.com/hapijs/bell/issues/184.

Specifically, I need this to avoid appending the request.path to the redirect URI, because I'm working with an OAuth2 provider that forbids any path (even a trailing slash).