### PR TITLE
Set SameSite=Strict for improved security

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,7 @@ internals.implementation = function (server, options) {
         password: settings.password,
         isSecure: settings.isSecure !== false,                  // Defaults to true
         isHttpOnly: settings.isHttpOnly !== false,              // Defaults to true
-        isSameSite: false,
+        isSameSite: 'Strict',
         ttl: settings.ttl,
         domain: settings.domain,
         ignoreErrors: true,


### PR DESCRIPTION
This was set to `false` a long time ago, mainly due to a Chrome bug that prevented OAuth from working with `Strict` mode (see https://github.com/aspnet/Security/issues/1231 for a good explanation of the infinite login loop).

That Chrome bug has since been fixed.

I have thoroughly tested that `Strict` works correctly now, across browsers. Chrome was the only browser to ever have an issue with this, though.