### PR TITLE
Use OIDC compliant profile from Auth0

### DIFF
--- a/lib/providers/auth0.js
+++ b/lib/providers/auth0.js
@@ -26,7 +26,7 @@ exports = module.exports = function (options) {
         token: `${auth0BaseUrl}/oauth/token`,
         profile: async function (credentials, params, get) {
 
-            const profile = await get(`${auth0BaseUrl}/userinfo`);          // https://auth0.com/docs/user-profile/normalized
+            const profile = await get(`${auth0BaseUrl}/userinfo`);  // https://auth0.com/docs/api/authentication#user-profile
             credentials.profile = {
                 id: profile.sub,
                 email: profile.email,

--- a/lib/providers/auth0.js
+++ b/lib/providers/auth0.js
@@ -28,7 +28,7 @@ exports = module.exports = function (options) {
 
             const profile = await get(`${auth0BaseUrl}/userinfo`);          // https://auth0.com/docs/user-profile/normalized
             credentials.profile = {
-                id: profile.user_id,
+                id: profile.sub,
                 email: profile.email,
                 displayName: profile.name,
                 name: {

--- a/test/providers/auth0.js
+++ b/test/providers/auth0.js
@@ -39,7 +39,7 @@ describe('auth0', () => {
         Hoek.merge(custom, mock.provider);
 
         const profile = {
-            user_id: 'auth0|1234567890',
+            sub: 'auth0|1234567890',
             name: 'steve smith',
             given_name: 'steve',
             family_name: 'smith',


### PR DESCRIPTION
This tiny change ensures that Auth0 won't break for bell users when Auth0 replaces their legacy user profile endpoint with an OIDC compliant one.

Note that this change does not require any action on the part of the user and it is backwards compatible because Auth0 is already returning `profile.sub` in addition to the old `profile.user_id` in order to make it easier to transition.