### PR TITLE
Use Stripe Express

### DIFF
--- a/lib/providers/stripe.js
+++ b/lib/providers/stripe.js
@@ -15,9 +15,9 @@ exports = module.exports = () => {
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: `https://${domain}/oauth/authorize`,
+        auth: `https://${domain}/express/oauth/authorize`,
         token: `https://${domain}/oauth/token`,
-        scope: ['read_only'],
+        scope: [],
         headers: { 'User-Agent': 'hapi-bell-stripe' },
         profile: async function (credentials, params, get) {
 

--- a/lib/providers/stripe.js
+++ b/lib/providers/stripe.js
@@ -10,11 +10,11 @@ const Joi = require('joi');
 const internals = {
     schema: Joi.object({
         express: Joi.boolean().optional()
-    }).required()
+    }).optional()
 };
 
 
-exports = module.exports = (options) => {
+exports = module.exports = (options = {}) => {
 
     const settings = Joi.attempt(options, internals.schema);
     const domain = 'connect.stripe.com';

--- a/lib/providers/stripe.js
+++ b/lib/providers/stripe.js
@@ -2,20 +2,28 @@
 
 // Load modules
 
+const Joi = require('joi');
+
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    schema: Joi.object({
+        express: Joi.boolean().optional()
+    }).required()
+};
 
 
-exports = module.exports = () => {
+exports = module.exports = (options) => {
 
+    const settings = Joi.attempt(options, internals.schema);
     const domain = 'connect.stripe.com';
+    const authPrefix = settings.express ? '/express' : '';
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: `https://${domain}/express/oauth/authorize`,
+        auth: `https://${domain}${authPrefix}/oauth/authorize`,
         token: `https://${domain}/oauth/token`,
         scope: [],
         headers: { 'User-Agent': 'hapi-bell-stripe' },

--- a/test/providers/stripe.js
+++ b/test/providers/stripe.js
@@ -30,7 +30,67 @@ describe('stripe', () => {
         const server = Hapi.server({ host: 'localhost', port: 80 });
         await server.register(Bell);
 
-        const custom = Bell.providers.stripe();
+        const custom = Bell.providers.stripe({});
+        Hoek.merge(custom, mock.provider);
+
+        const profile = {
+            id: '1234',
+            email: 'foo@example.com',
+            business_name: 'Acme, Inc.',
+            display_name: 'ACME Corp'
+        };
+
+        Mock.override('https://456@connect.stripe.com/v1/account', profile);
+
+        server.auth.strategy('custom', 'bell', {
+            password: 'cookie_encryption_password_secure',
+            isSecure: false,
+            clientId: 'stripe',
+            clientSecret: 'secret',
+            provider: custom
+        });
+
+        server.route({
+            method: '*',
+            path: '/login',
+            config: {
+                auth: 'custom',
+                handler: function (request, h) {
+
+                    return request.auth.credentials;
+                }
+            }
+        });
+
+        const res1 = await server.inject('/login');
+        const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
+
+        const res2 = await mock.server.inject(res1.headers.location);
+
+        const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
+        expect(res3.result).to.equal({
+            provider: 'custom',
+            token: '456',
+            expiresIn: 3600,
+            refreshToken: undefined,
+            query: {},
+            profile: {
+                id: '1234',
+                email: 'foo@example.com',
+                legalName: 'Acme, Inc.',
+                displayName: 'ACME Corp',
+                raw: profile
+            }
+        });
+    });
+
+    it('authenticates with mock using express option', async (flags) => {
+
+        const mock = await Mock.v2(flags);
+        const server = Hapi.server({ host: 'localhost', port: 80 });
+        await server.register(Bell);
+
+        const custom = Bell.providers.stripe({ express: true });
         Hoek.merge(custom, mock.provider);
 
         const profile = {

--- a/test/providers/stripe.js
+++ b/test/providers/stripe.js
@@ -30,7 +30,7 @@ describe('stripe', () => {
         const server = Hapi.server({ host: 'localhost', port: 80 });
         await server.register(Bell);
 
-        const custom = Bell.providers.stripe({});
+        const custom = Bell.providers.stripe();
         Hoek.merge(custom, mock.provider);
 
         const profile = {


### PR DESCRIPTION
"Express", as Stripe calls it, is a new flow for setting up Stripe Connect accounts. It is more friendly to users and looks better. Stripe is recommending using this going forward, though the older "Standard" account setup is still available.

I'm not sure what the semver policy is here for changes to providers, but this should probably be considered a breaking change for Stripe users, to be safe, since there are some slight differences when interacting with Stripe Express accounts via their API. There are minimal changes for `bell` users, though.