### PR TITLE
Ensure Auth0 profile is availabe in all cases

### DIFF
--- a/lib/providers/auth0.js
+++ b/lib/providers/auth0.js
@@ -24,6 +24,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: `${auth0BaseUrl}/authorize`,
         token: `${auth0BaseUrl}/oauth/token`,
+        scope: ['openid', 'profile', 'email'],
         profile: async function (credentials, params, get) {
 
             const profile = await get(`${auth0BaseUrl}/userinfo`);  // https://auth0.com/docs/api/authentication#user-profile


### PR DESCRIPTION
This is a bugfix for Auth0’s “Last time you logged in with” flow. Previously, if a user clicked on their existing session instead of the "Not your account?" link, then `request.auth.credentials` would not contain the user's profile information. That was very confusing because `bell` normally provides the full profile. The bug was a hard one to track down, since it only happens to users who visit the login page while they are already logged in.

This PR fixes the problem by explicitly requesting all of the scopes necessary for `bell` to function as intended. Auth0's APIs behave themselves when you do this. 😄 