### PR TITLE
Update LinkedIn to use new lite profile

### DIFF
--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -2,8 +2,6 @@
 
 // Load modules
 
-const Crypto = require('crypto');
-
 
 // Declare internals
 
@@ -15,24 +13,18 @@ exports = module.exports = function (options) {
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: 'https://www.linkedin.com/uas/oauth2/authorization',
-        token: 'https://www.linkedin.com/uas/oauth2/accessToken',
+        auth: 'https://www.linkedin.com/oauth/v2/authorization',
+        token: 'https://www.linkedin.com/oauth/v2/accessToken',
         scope: ['r_liteprofile', 'r_emailaddress'],
         scopeSeparator: ',',
         profile: async function (credentials, params, get) {
-
-            const query = {
-                format: 'json',
-                appsecret_proof: Crypto.createHmac('sha256', this.clientSecret).update(credentials.token).digest('hex')
-            };
-
             let fields = '';
             if (this.providerParams && this.providerParams.fields) {
                 fields = '?projection=' + this.providerParams.fields;
             }
 
-            const profile = await get('https://api.linkedin.com/v2/me' + fields, query);
-            const email = await get('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))', query);
+            const profile = await get('https://api.linkedin.com/v2/me' + fields);
+            const email = await get('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))');
 
             credentials.profile = {
                 id: profile.id,
@@ -40,7 +32,7 @@ exports = module.exports = function (options) {
                     first: profile.firstName.localized[Object.keys(profile.firstName.localized)[0]],
                     last: profile.lastName.localized[Object.keys(profile.lastName.localized)[0]]
                 },
-                email: email['handle~'].emailAddress,
+                email: email.elements[0]['handle~'].emailAddress,
                 raw: {
                     profile,
                     email

--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -18,6 +18,7 @@ exports = module.exports = function (options) {
         scope: ['r_liteprofile', 'r_emailaddress'],
         scopeSeparator: ',',
         profile: async function (credentials, params, get) {
+
             let fields = '';
             if (this.providerParams && this.providerParams.fields) {
                 fields = '?projection=' + this.providerParams.fields;

--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -17,7 +17,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: 'https://www.linkedin.com/uas/oauth2/authorization',
         token: 'https://www.linkedin.com/uas/oauth2/accessToken',
-        scope: ['r_basicprofile', 'r_emailaddress'],
+        scope: ['r_liteprofile', 'r_emailaddress'],
         scopeSeparator: ',',
         profile: async function (credentials, params, get) {
 
@@ -28,20 +28,23 @@ exports = module.exports = function (options) {
 
             let fields = '';
             if (this.providerParams && this.providerParams.fields) {
-                fields = this.providerParams.fields;
+                fields = '?projection=' + this.providerParams.fields;
             }
 
-            const profile = await get('https://api.linkedin.com/v1/people/~' + fields, query);
+            const profile = await get('https://api.linkedin.com/v2/me' + fields, query);
+            const email = await get('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))', query);
 
             credentials.profile = {
                 id: profile.id,
                 name: {
-                    first: profile.firstName,
-                    last: profile.lastName
+                    first: profile.firstName.localized[Object.keys(profile.firstName.localized)[0]],
+                    last: profile.lastName.localized[Object.keys(profile.lastName.localized)[0]]
                 },
-                email: profile.emailAddress,
-                headline: profile.headline,
-                raw: profile
+                email: email['handle~'].emailAddress,
+                raw: {
+                    profile,
+                    email
+                }
             };
         }
     };

--- a/test/mock.js
+++ b/test/mock.js
@@ -258,7 +258,12 @@ exports.override = function (uri, payload) {
 
             if (dest.indexOf(uri) === 0) {
                 if (typeof payload === 'function') {
-                    await payload(dest);
+                    const res = await payload(dest);
+
+                    if (res) {
+                        return { res: { statusCode: 200 }, payload: JSON.stringify(res) };
+                    }
+
                     team.attend();
                     return { res: { statusCode: 200 }, payload: '{"x":1}' };
                 }

--- a/test/providers/linkedin.js
+++ b/test/providers/linkedin.js
@@ -29,13 +29,41 @@ describe('linkedin', () => {
 
         const profile = {
             id: '1234567890',
-            firstName: 'steve',
-            lastName: 'smith',
-            emailAddress: 'steve.smith@domain.com',
-            headline: 'Master of the universe'
+            firstName: {
+                localized: {
+                    en_US: 'steve'
+                },
+                preferredLocal: {
+                    country: 'US',
+                    language: 'en'
+                }
+            },
+            lastName: {
+                localized: {
+                    en_US: 'smith'
+                },
+                preferredLocal: {
+                    country: 'US',
+                    language: 'en'
+                }
+            }
         };
 
-        Mock.override('https://api.linkedin.com/v1/people/~', profile);
+        const email = {
+            handle: 'urn:li:emailAddress:3775708763',
+            'handle~': {
+                emailAddress: 'steve.smith@domain.com'
+            }
+        };
+
+        Mock.override('https://api.linkedin.com/v2', (dest) => {
+
+            if (dest.startsWith('https://api.linkedin.com/v2/me')) {
+                return profile;
+            }
+
+            return email;
+        });
 
         server.auth.strategy('custom', 'bell', {
             password: 'cookie_encryption_password_secure',
@@ -76,8 +104,10 @@ describe('linkedin', () => {
                     last: 'smith'
                 },
                 email: 'steve.smith@domain.com',
-                headline: 'Master of the universe',
-                raw: profile
+                raw: {
+                    profile,
+                    email
+                }
             }
         });
     });
@@ -97,15 +127,44 @@ describe('linkedin', () => {
 
         const profile = {
             id: '1234567890',
-            firstName: 'steve',
-            lastName: 'smith',
-            headline: 'Master of the universe'
+            firstName: {
+                localized: {
+                    en_US: 'steve'
+                },
+                preferredLocal: {
+                    country: 'US',
+                    language: 'en'
+                }
+            },
+            lastName: {
+                localized: {
+                    en_US: 'smith'
+                },
+                preferredLocal: {
+                    country: 'US',
+                    language: 'en'
+                }
+            }
         };
+
+        const email = {
+            handle: 'urn:li:emailAddress:3775708763',
+            'handle~': {
+                emailAddress: 'steve.smith@domain.com'
+            }
+        };
+
+        let profileChecked = false;
 
         const get = (url, query) => {
 
-            expect(url).to.equal('https://api.linkedin.com/v1/people/~(id,firstName)');
-            return profile;
+            if (!profileChecked) {
+                expect(url).to.equal('https://api.linkedin.com/v2/me?projection=(id,firstName)');
+                profileChecked = true;
+                return profile;
+            }
+
+            return email;
         };
 
         await custom.profile({ token: '456' }, null, get);

--- a/test/providers/linkedin.js
+++ b/test/providers/linkedin.js
@@ -168,17 +168,25 @@ describe('linkedin', () => {
                 return profile;
             }
 
+            expect(url).to.equal('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))');
+
             return email;
         };
 
         await custom.profile({ token: '456' }, null, get);
 
         delete custom.providerParams.fields;
+        profileChecked = false;
 
         const get2 = (url, query) => {
 
-            expect(url).to.equal('https://api.linkedin.com/v1/people/~');
-            return profile;
+            if (!profileChecked) {
+                expect(url).to.equal('https://api.linkedin.com/v2/me');
+                profileChecked = true;
+                return profile;
+            }
+
+            return email;
         };
 
         await custom.profile({ token: '456' }, null, get2);

--- a/test/providers/linkedin.js
+++ b/test/providers/linkedin.js
@@ -50,10 +50,12 @@ describe('linkedin', () => {
         };
 
         const email = {
-            handle: 'urn:li:emailAddress:3775708763',
-            'handle~': {
-                emailAddress: 'steve.smith@domain.com'
-            }
+            elements: [{
+                handle: 'urn:li:emailAddress:3775708763',
+                'handle~': {
+                    emailAddress: 'steve.smith@domain.com'
+                }
+            }]
         };
 
         Mock.override('https://api.linkedin.com/v2', (dest) => {
@@ -148,10 +150,12 @@ describe('linkedin', () => {
         };
 
         const email = {
-            handle: 'urn:li:emailAddress:3775708763',
-            'handle~': {
-                emailAddress: 'steve.smith@domain.com'
-            }
+            elements: [{
+                handle: 'urn:li:emailAddress:3775708763',
+                'handle~': {
+                    emailAddress: 'steve.smith@domain.com'
+                }
+            }]
         };
 
         let profileChecked = false;


### PR DESCRIPTION
### Changes
 - Switched to use the new `liteprofile` scope
 - Grabs email from new dedicated endpoint

Will be testing this in another app tomorrow just to make sure I didn't miss anything.

Note: I had to update mock to support overriding both the endpoints - not sure if thats the best way...

Resolves #390 