### PR TITLE
Allow isSameSite customization

### DIFF
--- a/API.md
+++ b/API.md
@@ -147,6 +147,7 @@ Each strategy accepts the following optional settings:
 - `cookie` - the name of the cookie used to manage the temporary state. Defaults to
   `'bell-provider'` where 'provider' is the provider name (or `'custom'` for custom providers). For
   example, the Twitter cookie name defaults to `'bell-twitter'`.
+- `isSameSite` - sets the cookie same site option. Defaults to `Strict`.
 - `isSecure` - sets the cookie secure flag. Defaults to `true`.
 - `isHttpOnly` - sets the cookie HTTP only flag. Defaults to `true`.
 - `ttl` - cookie time-to-live in milliseconds. Defaults to `null` (session time-life - cookies are

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,6 +62,7 @@ internals.schema = Joi.object({
         otherwise: Joi.alternatives().try(Joi.string().allow(''), Joi.object())
     }).required(),
     cookie: Joi.string(),
+    isSameSite: Joi.string().allow(false).default('Strict'),
     isSecure: internals.flexBoolean,
     isHttpOnly: internals.flexBoolean,
     ttl: Joi.number(),
@@ -114,7 +115,7 @@ internals.implementation = function (server, options) {
         password: settings.password,
         isSecure: settings.isSecure !== false,                  // Defaults to true
         isHttpOnly: settings.isHttpOnly !== false,              // Defaults to true
-        isSameSite: 'Strict',
+        isSameSite: settings.isSameSite,
         ttl: settings.ttl,
         domain: settings.domain,
         ignoreErrors: true,


### PR DESCRIPTION
Fixes #395 by allowing customization of the `isSameSite` param.