### PR TITLE
Add support for hapi 18

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -353,7 +353,7 @@ internals.refreshRedirect = function (request, name, protocol, settings, credent
         return h.unauthenticated(Boom.internal('Missing ' + name + ' request token cookie'), { credentials });
     }
 
-    const refreshQuery = Object.assign({}, request.url.query, { refresh: 1 });
+    const refreshQuery = Object.assign({}, request.query, { refresh: 1 });
     const refreshUrl = internals.location(request, protocol, settings.location) + '?' + internals.queryString(refreshQuery);
     return h.response(`<html><head><meta http-equiv="refresh" content="0;URL='${refreshUrl}'"></head><body></body></html>`).takeover();
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "code": "5.x.x",
-    "hapi": "17.x.x",
+    "hapi": "18.x.x",
     "hawk": "7.x.x",
     "lab": "17.x.x",
     "teamwork": "3.x.x"

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth', async (flags) => {
 
         const mock = await Mock.v1(flags);
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -53,7 +53,7 @@ describe('Bell', () => {
         expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+        expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -63,7 +63,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth using RSA-SHA1 signing', async (flags) => {
 
         const mock = await Mock.v1(flags, { signatureMethod: 'RSA-SHA1' });
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -91,7 +91,7 @@ describe('Bell', () => {
         expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+        expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -101,7 +101,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth2', async (flags) => {
 
         const mock = await Mock.v2(flags);
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -125,11 +125,11 @@ describe('Bell', () => {
         });
 
         const res1 = await server.inject('/login');
-        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
         const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+        expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -138,7 +138,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth2 and basic authentication', async (flags) => {
 
         const mock = await Mock.v2(flags, { useParamsAuth: false });
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -163,10 +163,10 @@ describe('Bell', () => {
 
         const res1 = await server.inject('/login');
         const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
-        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+        expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -175,7 +175,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth2 with custom client secret options', async (flags) => {
 
         const mock = await Mock.v2(flags, false);
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -200,10 +200,10 @@ describe('Bell', () => {
 
         const res1 = await server.inject('/login');
         const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
-        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=customSecret&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=customSecret&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+        expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -213,7 +213,7 @@ describe('Bell', () => {
     it('authenticates an endpoint via oauth2 with custom client secret options and params auth', async (flags) => {
 
         const mock = await Mock.v2(flags, true);                        // Sets useParamsAuth = true
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -238,10 +238,10 @@ describe('Bell', () => {
 
         const res1 = await server.inject('/login');
         const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
-        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=customSecret&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+        expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=customSecret&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
         const res2 = await mock.server.inject(res1.headers.location);
-        expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+        expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
         const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
         expect(res3.result.provider).to.equal('custom');
@@ -251,7 +251,7 @@ describe('Bell', () => {
     it('overrides cookie name', async (flags) => {
 
         const mock = await Mock.v1(flags);
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom', 'bell', {
@@ -282,7 +282,7 @@ describe('Bell', () => {
     it('allows multiple custom provider names', async (flags) => {
 
         const mock = await Mock.v1(flags);
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         server.auth.strategy('custom_1', 'bell', {
@@ -341,7 +341,7 @@ describe('Bell', () => {
 
     it('exposes OAuth via plugin', async () => {
 
-        const server = Hapi.server({ host: 'localhost', port: 80 });
+        const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
         expect(server.plugins.bell.oauth.Client).to.be.function();

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -28,7 +28,7 @@ describe('Bell', () => {
 
         it('errors on missing oauth_verifier', async () => {
 
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -57,7 +57,7 @@ describe('Bell', () => {
 
         it('attempts to perform html redirection on missing cookie on token step', async () => {
 
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -82,12 +82,12 @@ describe('Bell', () => {
 
             const res = await server.inject('/login?oauth_token=123&oauth_verifier=123');
             expect(res.statusCode).to.equal(200);
-            expect(res.result).to.equal('<html><head><meta http-equiv=\"refresh\" content=\"0;URL=\'http://localhost:80/login?oauth_token=123&oauth_verifier=123&refresh=1\'\"></head><body></body></html>');
+            expect(res.result).to.equal('<html><head><meta http-equiv=\"refresh\" content=\"0;URL=\'http://localhost:8080/login?oauth_token=123&oauth_verifier=123&refresh=1\'\"></head><body></body></html>');
         });
 
         it('errors on missing cookie on token step (with refresh)', async () => {
 
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -116,7 +116,7 @@ describe('Bell', () => {
 
         it('errors on rejected query parameter', async () => {
 
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -146,7 +146,7 @@ describe('Bell', () => {
         it('fails getting temporary credentials', async (flags) => {
 
             const mock = await Mock.v1(flags, { failTemporary: true });
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -176,7 +176,7 @@ describe('Bell', () => {
         it('fails getting token credentials', async (flags) => {
 
             const mock = await Mock.v1(flags, { failToken: true });
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -211,7 +211,7 @@ describe('Bell', () => {
         it('passes credentials on error (temporary error)', async (flags) => {
 
             const mock = await Mock.v1(flags, { failTemporary: true });
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -244,7 +244,7 @@ describe('Bell', () => {
         it('passes credentials on error (token error)', async (flags) => {
 
             const mock = await Mock.v1(flags, { failToken: true });
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -282,7 +282,7 @@ describe('Bell', () => {
         it('does not pass on runtime query params by default', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -312,7 +312,7 @@ describe('Bell', () => {
         it('passes on runtime query params with allowRuntimeProviderParams', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -343,7 +343,7 @@ describe('Bell', () => {
         it('authenticates an endpoint via oauth with auth provider parameters', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -371,13 +371,13 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?special=true&oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123&extra=true');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123&extra=true');
         });
 
         it('authenticates an endpoint via oauth with a function as provider parameters', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -405,13 +405,13 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?value=bar&oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123&extra=true');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123&extra=true');
         });
 
         it('passes profileParams', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.twitter();
@@ -457,7 +457,7 @@ describe('Bell', () => {
         it('errors on invalid resource request (mock Twitter)', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.twitter();
@@ -490,7 +490,7 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.statusCode).to.equal(500);
@@ -499,7 +499,7 @@ describe('Bell', () => {
         it('authenticates with mock Twitter with skip profile', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.twitter();
@@ -544,7 +544,7 @@ describe('Bell', () => {
         it('errors on mismatching token', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -573,14 +573,14 @@ describe('Bell', () => {
 
             await mock.server.inject(res1.headers.location);
 
-            const res2 = await server.inject({ url: 'http://localhost:80/login?oauth_token=2&oauth_verifier=123', headers: { cookie } });
+            const res2 = await server.inject({ url: 'http://localhost:8080/login?oauth_token=2&oauth_verifier=123', headers: { cookie } });
             expect(res2.statusCode).to.equal(500);
         });
 
         it('errors if isSecure is true when protocol is not https', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -610,7 +610,7 @@ describe('Bell', () => {
         it('passes if isSecure is true when protocol is https (forced)', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -638,7 +638,7 @@ describe('Bell', () => {
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('https://localhost:80/login?oauth_token=1&oauth_verifier=');
+            expect(res2.headers.location).to.contain('https://localhost:8080/login?oauth_token=1&oauth_verifier=');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.statusCode).to.equal(200);
@@ -647,7 +647,7 @@ describe('Bell', () => {
         it('passes if isSecure is true when protocol is https (location)', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -684,7 +684,7 @@ describe('Bell', () => {
         it('forces https in callback_url when set in options', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -711,7 +711,7 @@ describe('Bell', () => {
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('https://localhost:80/login?oauth_token=1&oauth_verifier=');
+            expect(res2.headers.location).to.contain('https://localhost:8080/login?oauth_token=1&oauth_verifier=');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.statusCode).to.equal(200);
@@ -720,7 +720,7 @@ describe('Bell', () => {
         it('uses location setting in callback_url when set in options', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -757,7 +757,7 @@ describe('Bell', () => {
         it('returns resource response stream', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -793,7 +793,7 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.result).to.equal('some text reply');
@@ -802,7 +802,7 @@ describe('Bell', () => {
         it('returns raw resource response', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -839,7 +839,7 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.result).to.equal('{"a":"5"}');
@@ -848,7 +848,7 @@ describe('Bell', () => {
         it('returns resource POST response', async (flags) => {
 
             const mock = await Mock.v1(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -884,7 +884,7 @@ describe('Bell', () => {
             expect(res1.headers.location).to.equal(mock.uri + '/auth?oauth_token=1');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.equal('http://localhost:80/login?oauth_token=1&oauth_verifier=123');
+            expect(res2.headers.location).to.equal('http://localhost:8080/login?oauth_token=1&oauth_verifier=123');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.result).to.equal('{"a":"5"}');
@@ -896,7 +896,7 @@ describe('Bell', () => {
         it('authenticates an endpoint with provider parameters', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -921,13 +921,13 @@ describe('Bell', () => {
             });
 
             const res = await server.inject('/login');
-            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
         });
 
         it('forces https in redirect_uri when set in options', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -953,11 +953,11 @@ describe('Bell', () => {
             });
 
             const res1 = await server.inject('/login');
-            expect(res1.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res1.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('https://localhost:80/login?code=1&state=');
+            expect(res2.headers.location).to.contain('https://localhost:8080/login?code=1&state=');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.statusCode).to.equal(200);
@@ -966,7 +966,7 @@ describe('Bell', () => {
         it('uses location setting in redirect_uri when set in options', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1005,7 +1005,7 @@ describe('Bell', () => {
         it('ignores empty string returned by location setting (function)', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1031,13 +1031,13 @@ describe('Bell', () => {
             });
 
             const res = await server.inject('/login');
-            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
         });
 
         it('uses location setting (function) in redirect_uri when set in options', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1088,7 +1088,7 @@ describe('Bell', () => {
         it('authenticates an endpoint with custom scope', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1119,7 +1119,7 @@ describe('Bell', () => {
         it('authenticates an endpoint with custom function scope', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1150,7 +1150,7 @@ describe('Bell', () => {
         it('authenticates with mock Instagram with skip profile', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.instagram();
@@ -1195,7 +1195,7 @@ describe('Bell', () => {
         it('authenticates an endpoint with runtime query parameters', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1221,13 +1221,13 @@ describe('Bell', () => {
             });
 
             const res = await server.inject('/login?runtime=5');
-            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&runtime=5&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&runtime=5&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
         });
 
         it('allows runtime state', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1256,14 +1256,14 @@ describe('Bell', () => {
             });
 
             const res = await server.inject('/login?state=something');
-            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
             expect(res.headers.location).to.contain('something');
         });
 
         it('allows empty or null runtime state', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1292,13 +1292,13 @@ describe('Bell', () => {
             });
 
             const res = await server.inject('/login?state=something');
-            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
         });
 
         it('fails on missing state', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1323,19 +1323,19 @@ describe('Bell', () => {
 
             const res1 = await server.inject('/login');
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
-            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+            expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
-            const res3 = await server.inject({ url: 'http://localhost:80/login?code=1', headers: { cookie } });
+            const res3 = await server.inject({ url: 'http://localhost:8080/login?code=1', headers: { cookie } });
             expect(res3.statusCode).to.equal(500);
         });
 
         it('does not include runtime query parameters by default', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1366,7 +1366,7 @@ describe('Bell', () => {
         it('refreshes & errors on missing cookie in token step', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1392,10 +1392,10 @@ describe('Bell', () => {
             const res1 = await server.inject('/login');
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
             expect(cookie).to.exist();
-            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+            expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
             const res3 = await server.inject(res2.headers.location);
             expect(res3.statusCode).to.equal(200);
@@ -1409,7 +1409,7 @@ describe('Bell', () => {
         it('errors on mismatching state', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1434,19 +1434,19 @@ describe('Bell', () => {
 
             const res1 = await server.inject('/login');
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
-            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res1.headers.location).to.contain(mock.uri + '/auth?client_id=test&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('http://localhost:80/login?code=1&state=');
+            expect(res2.headers.location).to.contain('http://localhost:8080/login?code=1&state=');
 
-            const res3 = await server.inject({ url: 'http://localhost:80/login?code=1&state=xx', headers: { cookie } });
+            const res3 = await server.inject({ url: 'http://localhost:8080/login?code=1&state=xx', headers: { cookie } });
             expect(res3.statusCode).to.equal(500);
         });
 
         it('errors on failed token request', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1486,7 +1486,7 @@ describe('Bell', () => {
         it('errors on errored token request (500)', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1526,7 +1526,7 @@ describe('Bell', () => {
         it('errors on errored token request (<200)', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1568,7 +1568,7 @@ describe('Bell', () => {
         it('errors on invalid token request response', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1608,7 +1608,7 @@ describe('Bell', () => {
         it('passes if the client secret is not modified in route', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1643,7 +1643,7 @@ describe('Bell', () => {
         it('errors on failed profile request', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1683,7 +1683,7 @@ describe('Bell', () => {
         it('errors on errored profile request', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1723,7 +1723,7 @@ describe('Bell', () => {
         it('errors on invalid profile request', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1763,7 +1763,7 @@ describe('Bell', () => {
         it('errors on rejected query parameter', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1800,7 +1800,7 @@ describe('Bell', () => {
         it('errors if isSecure is true when protocol is not https', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1831,7 +1831,7 @@ describe('Bell', () => {
         it('passes if isSecure is true when protocol is https (location)', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1870,7 +1870,7 @@ describe('Bell', () => {
         it('passes if isSecure is true when protocol is https (forced)', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             server.auth.strategy('custom', 'bell', {
@@ -1896,11 +1896,11 @@ describe('Bell', () => {
             });
 
             const res1 = await server.inject('/login');
-            expect(res1.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Flocalhost%3A80%2Flogin&state=');
+            expect(res1.headers.location).to.contain(mock.uri + '/auth?special=true&client_id=test&response_type=code&redirect_uri=https%3A%2F%2Flocalhost%3A8080%2Flogin&state=');
             const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
 
             const res2 = await mock.server.inject(res1.headers.location);
-            expect(res2.headers.location).to.contain('https://localhost:80/login?code=1&state=');
+            expect(res2.headers.location).to.contain('https://localhost:8080/login?code=1&state=');
 
             const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
             expect(res3.statusCode).to.equal(200);
@@ -1909,7 +1909,7 @@ describe('Bell', () => {
         it('passes profile get params', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();
@@ -1956,7 +1956,7 @@ describe('Bell', () => {
         it('passes profileParams', async (flags) => {
 
             const mock = await Mock.v2(flags);
-            const server = Hapi.server({ host: 'localhost', port: 80 });
+            const server = Hapi.server({ host: 'localhost', port: 8080 });
             await server.register(Bell);
 
             const custom = Bell.providers.facebook();


### PR DESCRIPTION
This PR includes two fixes related to [hapi 18](https://github.com/hapijs/hapi/issues/3871):

1. Many tests broke because hapi now strips the default port from `request.info.host` (a side effect of using the WHATWG URL API) – causing lots of assertions to fail. I decided to use a non-default port in the tests instead of removing the default port from the assertions. This verifies that port info is still propagated correctly.
2. `request.url.query` is no longer available. I’ve changed it to `request.query` which works for hapi 18 and older versions. (I’ve tested it with hapi 17 and 18). This fixes #394.