### PR TITLE
Fix auth info for office365

### DIFF
--- a/lib/providers/office365.js
+++ b/lib/providers/office365.js
@@ -18,12 +18,12 @@ exports = module.exports = function (options) {
         scope: ['openid', 'offline_access', 'profile'],
         profile: async function (credentials, params, get) {
 
-            const profile = await get('https://outlook.office.com/api/v2.0/me');
+            const profile = await get('https://graph.microsoft.com/v1.0/me');
 
             credentials.profile = {
-                id: profile.Id,
-                displayName: profile.DisplayName,
-                email: profile.EmailAddress,
+                id: profile.id,
+                displayName: profile.displayName,
+                email: profile.mail,
                 raw: profile
             };
         }


### PR DESCRIPTION
In the outlook api documentation now points to graph api to retrieve people information.