### PR TITLE
 Fix auth info for office365 

### DIFF
--- a/lib/providers/office365.js
+++ b/lib/providers/office365.js
@@ -18,12 +18,12 @@ exports = module.exports = function (options) {
         scope: ['openid', 'offline_access', 'profile'],
         profile: async function (credentials, params, get) {
 
-            const profile = await get('https://outlook.office.com/api/v2.0/me');
+            const profile = await get('https://graph.microsoft.com/v1.0/me');
 
             credentials.profile = {
-                id: profile.Id,
-                displayName: profile.DisplayName,
-                email: profile.EmailAddress,
+                id: profile.id,
+                displayName: profile.displayName,
+                email: profile.mail,
                 raw: profile
             };
         }

--- a/lib/providers/office365.js
+++ b/lib/providers/office365.js
@@ -15,7 +15,7 @@ exports = module.exports = function (options) {
         useParamsAuth: true,
         auth: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
         token: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
-        scope: ['openid', 'offline_access', 'profile'],
+        scope: ['openid', 'offline_access', 'profile', 'user.read'],
         profile: async function (credentials, params, get) {
 
             const profile = await get('https://graph.microsoft.com/v1.0/me');


### PR DESCRIPTION
In the outlook api documentation now points to graph api to retrieve people information.