### PR TITLE
Updates slack example

### DIFF
--- a/examples/slack.js
+++ b/examples/slack.js
@@ -16,7 +16,18 @@ internals.start = async function () {
         password: 'cookie_encryption_password_secure',
         isSecure: false,
         clientId: '',
-        clientSecret: ''
+        clientSecret: '',
+        isSameSite: 'Lax', // fixes issue with Auth Redirect Loop
+        scope: [
+          'identify',
+          'groups:read',
+          'channels:read',
+          'im:read',
+          'mpim:read',
+          'users:read',
+          'users:read.email',
+          'users.profile:read',
+        ], // fixes non admin users don't get the proper scope.
     });
 
     server.route({

--- a/examples/slack.js
+++ b/examples/slack.js
@@ -19,15 +19,15 @@ internals.start = async function () {
         clientSecret: '',
         isSameSite: 'Lax', // fixes issue with Auth Redirect Loop
         scope: [
-          'identify',
-          'groups:read',
-          'channels:read',
-          'im:read',
-          'mpim:read',
-          'users:read',
-          'users:read.email',
-          'users.profile:read',
-        ], // fixes non admin users don't get the proper scope.
+            'identify',
+            'groups:read',
+            'channels:read',
+            'im:read',
+            'mpim:read',
+            'users:read',
+            'users:read.email',
+            'users.profile:read'
+        ] // fixes non admin users don't get the proper scope.
     });
 
     server.route({

--- a/examples/slack.js
+++ b/examples/slack.js
@@ -11,13 +11,25 @@ internals.start = async function () {
 
     const server = Hapi.server({ port: 8000 });
     await server.register(Bell);
+
+    /*
+    * You can pass in your own scope rules which admins rules
+    * get defaulted to identify.
+    *
+    */
+
     server.auth.strategy('slack', 'bell', {
         provider: 'slack',
         password: 'cookie_encryption_password_secure',
         isSecure: false,
         clientId: '',
         clientSecret: '',
-        isSameSite: 'Lax', // fixes issue with Auth Redirect Loop
+        /*
+        * isSameSite property
+        * Fixes: https://stackoverflow.com/questions/39748688/hapi-js-bell-auth-cookie-redirect-loop
+        isSameSite: 'Lax',
+        * You can pass in your own scope rules. You may find it's needed for admin
+        * rules which get defaulted to identify.
         scope: [
             'identify',
             'groups:read',
@@ -27,7 +39,8 @@ internals.start = async function () {
             'users:read',
             'users:read.email',
             'users.profile:read'
-        ] // fixes non admin users don't get the proper scope.
+        ]
+        */
     });
 
     server.route({

--- a/examples/slack.js
+++ b/examples/slack.js
@@ -23,7 +23,7 @@ internals.start = async function () {
         password: 'cookie_encryption_password_secure',
         isSecure: false,
         clientId: '',
-        clientSecret: '',
+        clientSecret: ''
         /*
         * isSameSite property
         * Fixes: https://stackoverflow.com/questions/39748688/hapi-js-bell-auth-cookie-redirect-loop


### PR DESCRIPTION
I propose this documentation change as it took hours to figure out and hopefully this will save someone else hours.

I was having issues with the redirect call back on my local machine. For some reason adding: isSameSite: 'Lax', fixed it. I have no idea why but for me it was redirecting from slack to my local endpoint. I think the example could have it like this or committed out. 

https://stackoverflow.com/questions/39748688/hapi-js-bell-auth-cookie-redirect-loop

The second scope array. This closes: https://github.com/hapijs/bell/issues/401 but basically, non admin users were getting the default scope: `scope: ['identify'], // Minimum scope required to identify the user` so with this I think it will show users how to let their non admin users pass custom scopes.