### PR TITLE
RFC 7636: Proof Key for Code Exchange

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ internals.schema = Joi.object({
         headers: Joi.object(),
         profile: Joi.func(),
         profileMethod: Joi.string().valid('get', 'post').default('get'),
+        pkce: Joi.string().valid('S256', 'plain').optional().when('protocol', { is: 'oauth2', otherwise: Joi.forbidden() }),
         scope: Joi.alternatives().try(
             Joi.array().items(Joi.string()),
             Joi.func()

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -12,7 +12,8 @@ const Wreck = require('@hapi/wreck');
 
 
 const internals = {
-    nonceLength: 22
+    nonceLength: 22,
+    codeVerifierLength: 128
 };
 
 
@@ -209,6 +210,20 @@ exports.v2 = function (settings) {
                 query: request.query
             };
 
+
+            if (settings.provider.pkce) {
+                state.codeVerifier = internals.createCodeVerifier();
+                if (settings.provider.pkce === 'S256') {
+                    query.code_challenge = internals.createCodeChallenge(state.codeVerifier);
+                    query.code_challenge_method = 'S256';
+                }
+
+                if (settings.provider.pkce === 'plain') {
+                    query.code_challenge = state.codeVerifier;
+                    query.code_challenge_method = 'plain';
+                }
+            }
+
             h.state(cookie, state);
             return h.redirect(settings.provider.auth + '?' + internals.queryString(query)).takeover();
         }
@@ -233,6 +248,10 @@ exports.v2 = function (settings) {
             code: request.query.code,
             redirect_uri: internals.location(request, protocol, settings.location)
         };
+
+        if (settings.provider.pkce) {
+            query.code_verifier = state.codeVerifier;
+        }
 
         if (settings.provider.useParamsAuth) {
             query.client_id = settings.clientId;
@@ -666,6 +685,20 @@ internals.Client.queryString = internals.queryString = function (params) {
     return fields.join('&');
 };
 
+internals.createCodeChallenge = function (codeVerifier) {
+
+    return Crypto.createHash('sha256')
+        .update(codeVerifier, 'ascii')
+        .digest('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+};
+
+internals.createCodeVerifier = function () {
+
+    return Cryptiles.randomString(internals.codeVerifierLength).replace(/_/g, '.').replace(/=/g, '~');
+};
 
 internals.getProtocol = function (request, settings) {
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -196,6 +196,10 @@ exports.v2 = async function (flags, options = {}) {
                         expires_in: 3600
                     };
 
+                    if (request.payload.code_verifier) {
+                        payload.code_verifier = request.payload.code_verifier;
+                    }
+
                     if (code.client_id === 'instagram') {
                         payload.user = {
                             id: '123456789',


### PR DESCRIPTION
PKCE ([RFC 7636](https://tools.ietf.org/html/rfc7636)) is a technique to secure public clients that don't use a client secret. 

It is primarily used by native and mobile apps, but the technique can be applied to any public client as well.

Although `hapi` and `bell` are usually used in places where a secret can be kept safely, someone might be using it as a public client. 

My motivation for this pull request is not because my application is public, but because I am using a provider which requires PKCE.

More information:
https://oauth.net/2/pkce/
https://www.oauth.com/oauth2-servers/pkce/
https://www.oauth.com/oauth2-servers/pkce/authorization-request/
