### PR TITLE
Use actual package name for plugin name

### DIFF
--- a/examples/okta.js
+++ b/examples/okta.js
@@ -11,7 +11,7 @@ const internals = {};
 internals.start = async function () {
 
     const server = Hapi.server({ port: 8000 });
-    await server.register([require('hapi-auth-cookie'), Bell]);
+    await server.register([require('@hapi/cookie'), Bell]);
 
     server.auth.strategy('session', 'cookie', {
         password: 'secret_cookie_encryption_password',      // Use something more secure in production

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,6 @@ exports.oauth = OAuth;
 // Plugin
 
 exports.plugin = {
-    name: 'bell',
     pkg: require('../package.json'),
     requirements: {
         hapi: '>=18.3.0'

--- a/test/index.js
+++ b/test/index.js
@@ -345,7 +345,7 @@ describe('Bell', () => {
         const server = Hapi.server({ host: 'localhost', port: 8080 });
         await server.register(Bell);
 
-        expect(server.plugins.bell.oauth.Client).to.be.function();
+        expect(server.plugins['@hapi/bell'].oauth.Client).to.be.function();
     });
 
     describe('simulate()', () => {


### PR DESCRIPTION
This PR fixes a problem I am having during my upgrade to hapi 18 and the new `@hapi` scoped package names.

My [hapi-doorkeeper](https://github.com/sholladay/hapi-doorkeeper) plugin [depends on](https://github.com/sholladay/hapi-doorkeeper/blob/master/index.js#L123-L126) `@hapi/cookie` and `@hapi/bell`. However, the `@hapi/bell` dependency was failing with this error when starting the server...

```js
Error: Plugin hapi-doorkeeper missing dependency @hapi/bell
```

It took a while to figure out that it's because `@hapi/bell` has a hardcoded plugin name that is different from the package name, which is inconsistent with `@hapi/cookie` and others. I've fixed this to be consistent with other plugins, in that the `@hapi/` prefix is part of the plugin name.

This is technically a breaking change. However, I think it may have been unintentionally omitted from bell v11, so in that sense it's a just a patch.