### PR TITLE
Support Okta custom authorization server

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -842,6 +842,7 @@ credentials.profile = {
 - `scope`: Defaults to `['openid', 'email', 'offline_access']`
 - `config`:
   - `uri`: Point to your Okta enterprise uri.  Intentionally no default as Okta is organization specific.
+  - `authorizationServerId`: If you are using a [custom authorization server](https://support.okta.com/help/s/article/Difference-Between-Okta-as-An-Authorization-Server-vs-Custom-Authorization-Server) you need to pass the alphanumeric ID here.
 - `auth`: https://your-organization.okta.com/oauth2/v1/authorize
 - `token`: https://your-organization.okta.com/oauth2/v1/token
 

--- a/lib/providers/okta.js
+++ b/lib/providers/okta.js
@@ -5,7 +5,8 @@ const Joi = require('@hapi/joi');
 
 const internals = {
     schema: Joi.object({
-        uri: Joi.string().uri().required()
+        uri: Joi.string().uri().required(),
+        authorizationServerId: Joi.string().alphanum()
     }).required()
 };
 
@@ -14,15 +15,20 @@ exports = module.exports = function (options) {
 
     const settings = Joi.attempt(options, internals.schema);
 
+    let baseUri = settings.uri + '/oauth2';
+    if (settings.authorizationServerId) {
+        baseUri += '/' + settings.authorizationServerId;
+    }
+
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: settings.uri + '/oauth2/v1/authorize',
-        token: settings.uri + '/oauth2/v1/token',
+        auth: baseUri + '/v1/authorize',
+        token: baseUri + '/v1/token',
         scope: ['profile', 'openid', 'email', 'offline_access'],
         profile: async function (credentials, params, get) {
 
-            const profile = await get(settings.uri + '/oauth2/v1/userinfo');
+            const profile = await get(baseUri + '/v1/userinfo');
 
             credentials.profile = {
                 id: profile.sub,

--- a/test/providers/okta.js
+++ b/test/providers/okta.js
@@ -90,4 +90,75 @@ describe('Okta', () => {
             }
         });
     });
+
+    it('authenticates with mock and custom uri and authorization server id', async (flags) => {
+
+        const mock = await Mock.v2(flags);
+        const server = Hapi.server({ host: 'localhost', port: 80 });
+        await server.register(Bell);
+
+        const custom = Bell.providers.okta({
+            uri: 'http://example.com',
+            authorizationServerId: 'abcd123'
+        });
+
+        expect(custom.auth).to.equal('http://example.com/oauth2/abcd123/v1/authorize');
+        expect(custom.token).to.equal('http://example.com/oauth2/abcd123/v1/token');
+
+        Hoek.merge(custom, mock.provider);
+
+        const profile = {
+            sub: '1234567890',
+            nickname: 'steve_smith',
+            given_name: 'steve',
+            middle_name: 'jared',
+            family_name: 'smith',
+            email: 'steve@example.com'
+        };
+
+        Mock.override('http://example.com/oauth2/abcd123/v1/userinfo', profile);
+
+        server.auth.strategy('custom', 'bell', {
+            password: 'cookie_encryption_password_secure',
+            isSecure: false,
+            clientId: 'okta',
+            clientSecret: 'secret',
+            provider: custom
+        });
+
+        server.route({
+            method: '*',
+            path: '/login',
+            config: {
+                auth: 'custom',
+                handler: function (request, h) {
+
+                    return request.auth.credentials;
+                }
+            }
+        });
+
+        const res1 = await server.inject('/login');
+        const cookie = res1.headers['set-cookie'][0].split(';')[0] + ';';
+
+        const res2 = await mock.server.inject(res1.headers.location);
+
+        const res3 = await server.inject({ url: res2.headers.location, headers: { cookie } });
+        expect(res3.result).to.equal({
+            provider: 'custom',
+            token: '456',
+            expiresIn: 3600,
+            refreshToken: undefined,
+            query: {},
+            profile: {
+                id: '1234567890',
+                username: 'steve@example.com',
+                displayName: 'steve_smith',
+                firstName: 'steve',
+                lastName: 'smith',
+                email: 'steve@example.com',
+                raw: profile
+            }
+        });
+    });
 });


### PR DESCRIPTION
[Okta custom authorization servers](https://support.okta.com/help/s/article/Difference-Between-Okta-as-An-Authorization-Server-vs-Custom-Authorization-Server) require the addition of an alphanumeric ID after the `/oauth2` URL segment which cannot be done using just the base `uri` option. I opted to implemented this change this way as to not require a major version bump, even though it might be cleaner to just drop the `/oauth2` part of the URL that Bell adds and force people to move it into their `uri` option.