### PR TITLE
Linkedin projection param should be parenthesised

### DIFF
--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -16,7 +16,7 @@ exports = module.exports = function (options) {
 
             let fields = '';
             if (this.providerParams && this.providerParams.fields) {
-                fields = '?projection=' + this.providerParams.fields;
+                fields = '?projection=(' + this.providerParams.fields + ')';
             }
 
             const profile = await get('https://api.linkedin.com/v2/me' + fields);


### PR DESCRIPTION
Documentation here:
https://docs.microsoft.com/en-us/linkedin/shared/integrations/people/profile-api?context=linkedin/compliance/context

Example Usage:

```
  server.auth.strategy('linkedin', 'bell', {
    provider: 'linkedin',
    password: options.sessionSecret,
    isSecure: false,
    clientId: options.linkedinClientId,
    clientSecret: options.linkedinClientSecret,
    providerParams: {
      redirect_uri: options.linkedinCallbackURL,
      fields: [
        'id',
        'firstName',
        'lastName',
        'profilePicture(displayImage~digitalmediaAsset:playableStreams)'
      ]
    }
  });
```