### PR TITLE
OAuth1: Added support for PLAINTEXT signature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ internals.provider = Joi.object({
         is: 'oauth',
         then: Joi.object({
             temporary: Joi.string().required(),
-            signatureMethod: Joi.valid('HMAC-SHA1', 'RSA-SHA1').default('HMAC-SHA1')
+            signatureMethod: Joi.valid('HMAC-SHA1', 'RSA-SHA1', 'PLAINTEXT').default('HMAC-SHA1')
         }),
         otherwise: Joi.object({
             scope: Joi.alternatives(

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -526,7 +526,7 @@ internals.Client.prototype.signature = function (method, baseUri, params, oauth,
 
     // 3.4.4.  PLAINTEXT
     if (this.settings.signatureMethod === 'PLAINTEXT') {
-      return tokenSecret ? (this.settings.clientSecret + internals.encode(tokenSecret)) : this.settings.clientSecret;
+        return tokenSecret ? (this.settings.clientSecret + internals.encode(tokenSecret)) : this.settings.clientSecret;
     }
 
     // Parameters Normalization (3.4.1.3.2)

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -524,6 +524,11 @@ internals.Client.baseUri = function (uri) {
 
 internals.Client.prototype.signature = function (method, baseUri, params, oauth, tokenSecret) {
 
+    // 3.4.4.  PLAINTEXT
+    if (this.settings.signatureMethod === 'PLAINTEXT') {
+      return tokenSecret ? (this.settings.clientSecret + internals.encode(tokenSecret)) : this.settings.clientSecret;
+    }
+
     // Parameters Normalization (3.4.1.3.2)
 
     const normalized = [];


### PR DESCRIPTION
Would be great if the PLAINTEXT signature as defined in https://tools.ietf.org/html/rfc5849#section-3.4.4 is supported too.
Seems pretty straight forward.