### PR TITLE
[master] Update documentation to use the correct authentication mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,7 +65,10 @@ internals.start = async function () {
         method: ['GET', 'POST'],    // Must handle both GET and POST
         path: '/login',             // The callback endpoint registered with the provider
         options: {
-            auth: 'twitter',
+            auth: {
+              mode: 'try',
+              strategy: 'twitter'
+            },
             handler: function (request, h) {
 
                 if (!request.auth.isAuthenticated) {
@@ -143,7 +146,10 @@ internals.start = async function () {
         method: ['GET', 'POST'],    // Must handle both GET and POST
         path: '/login',             // The callback endpoint registered with the provider
         options: {
-            auth: 'twitter',
+            auth: {
+              mode: 'try',
+              strategy: 'twitter'
+            },
             handler: function (request, h) {
 
                 if (!request.auth.isAuthenticated) {

--- a/examples/github.js
+++ b/examples/github.js
@@ -30,7 +30,10 @@ internals.start = async function () {
         method: ['GET', 'POST'],
         path: '/login',
         options: {
-            auth: 'github',
+            auth: {
+                strategy: 'github',
+                mode: 'try'
+            },
             handler: function (request, h) {
 
                 if (!request.auth.isAuthenticated) {

--- a/examples/okta.js
+++ b/examples/okta.js
@@ -33,7 +33,10 @@ internals.start = async function () {
         method: 'GET',
         path: '/auth/okta',
         options: {
-            auth: 'okta',
+            auth: {
+                strategy: 'okta',
+                mode: 'try'
+            },
             handler: function (request, h) {
 
                 if (!request.auth.isAuthenticated) {

--- a/examples/twitch.js
+++ b/examples/twitch.js
@@ -27,7 +27,10 @@ internals.start = async function () {
         method: ['GET', 'POST'],
         path: '/bell/door',
         options: {
-            auth: 'twitch',
+            auth: {
+                strategy: 'twitch',
+                mode: 'try'
+            },
             handler: function (request, h) {
 
                 if (!request.auth.isAuthenticated) {


### PR DESCRIPTION
Some authentication providers examples included a verification over the `request.auth.isAuthenticated` property even when the default authentication mode is set to `required` when the handler would have never been called.

Not sure if that was intended, but confused me a little bit since my handler was never being called on authentication errors.