### PR TITLE
Discord provider: update to use new links

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -136,12 +136,12 @@ credentials.profile = {
 
 ### Discord
 
-[Provider Documentation](https://discordapp.com/developers/docs/topics/oauth2)
+[Provider Documentation](https://discord.com/developers/docs/topics/oauth2)
 
 - `scope`: Defaults to `['email', 'identify']`
 - `config`: not applicable
-- `auth`: https://discordapp.com/api/oauth2/authorize
-- `token`: https://discordapp.com/api/oauth2/token
+- `auth`: https://discord.com/api/oauth2/authorize
+- `token`: https://discord.com/api/oauth2/token
 
 The default profile response will look like this:
 
@@ -155,7 +155,7 @@ credentials.profile = {
     verified: profile.verified,
     avatar: {
         id: profile.avatar,
-        url: 'https://discordapp.com/api/users/' + profile.id + '/avatars/' + profile.avatar + '.jpg'
+        url: 'https://discord.com/api/users/' + profile.id + '/avatars/' + profile.avatar + '.jpg'
     },
     raw: profile
 };

--- a/examples/discord.js
+++ b/examples/discord.js
@@ -12,7 +12,7 @@ internals.start = async function () {
     const server = Hapi.server({ port: 8000 });
     await server.register(Bell);
 
-    // Fill in your clientId and clientSecret: https://discordapp.com/developers/applications/me
+    // Fill in your clientId and clientSecret: https://discord.com/developers/applications/me
 
     server.auth.strategy('discord', 'bell', {
         provider: 'discord',

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -7,12 +7,12 @@ exports = module.exports = function () {
 
     return {
         protocol: 'oauth2',
-        auth: 'https://discordapp.com/api/oauth2/authorize',
-        token: 'https://discordapp.com/api/oauth2/token',
-        scope: ['email', 'identify'],                                   // https://discordapp.com/developers/docs/topics/oauth2#scopes
+        auth: 'https://discord.com/api/oauth2/authorize',
+        token: 'https://discord.com/api/oauth2/token',
+        scope: ['email', 'identify'],                                   // https://discord.com/developers/docs/topics/oauth2#scopes
         profile: async function (credentials, params, get) {
 
-            const profile = await get('https://discordapp.com/api/users/@me');
+            const profile = await get('https://discord.com/api/users/@me');
 
             credentials.profile = {
                 id: profile.id,

--- a/test/providers/discord.js
+++ b/test/providers/discord.js
@@ -27,7 +27,7 @@ describe('discord', () => {
         const custom = Bell.providers.discord();
         Hoek.merge(custom, mock.provider);
 
-        Mock.override('https://discordapp.com/api/users/@me', {
+        Mock.override('https://discord.com/api/users/@me', {
             id: '80351110224678912',
             username: 'Nelly',
             discriminator: '1337',

--- a/test/providers/discord.js
+++ b/test/providers/discord.js
@@ -34,7 +34,7 @@ describe('discord', () => {
             mfa_enabled: false,
             avatar: '8342729096ea3675442027381ff50dfe',
             verified: true,
-            email: 'nelly@discordapp.com'
+            email: 'nelly@discord.com'
         });
 
         server.auth.strategy('custom', 'bell', {
@@ -79,7 +79,7 @@ describe('discord', () => {
                     url: 'https://cdn.discordapp.com/avatars/80351110224678912/8342729096ea3675442027381ff50dfe.png'
                 },
                 verified: true,
-                email: 'nelly@discordapp.com',
+                email: 'nelly@discord.com',
                 raw: {
                     id: '80351110224678912',
                     username: 'Nelly',
@@ -87,7 +87,7 @@ describe('discord', () => {
                     mfa_enabled: false,
                     avatar: '8342729096ea3675442027381ff50dfe',
                     verified: true,
-                    email: 'nelly@discordapp.com'
+                    email: 'nelly@discord.com'
                 }
             }
         });


### PR DESCRIPTION
Discord said they would drop support for the `discordapp.com` domain sometime soon in favor of the `discord.com` domain.  This updates the links to avoid it from breaking users' code out of the blue.