### PR TITLE
Support OAuth1 client wreck options

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -396,6 +396,8 @@ exports.Client = internals.Client = function (options) {
         clientSecret: options.provider.signatureMethod === 'RSA-SHA1' ? options.clientSecret : internals.encode(options.clientSecret || '') + '&',
         signatureMethod: options.provider.signatureMethod
     };
+
+    this._wreckOptions = { ...options.wreck };
 };
 
 
@@ -451,6 +453,7 @@ internals.Client.prototype._request = async function (method, uri, params, oauth
     // Calculate OAuth header
 
     const requestOptions = {
+        ...this._wreckOptions,
         headers: {
             Authorization: internals.Client.header(oauth)
         }

--- a/test/oauth.js
+++ b/test/oauth.js
@@ -2150,6 +2150,12 @@ describe('Bell', () => {
             expect(client.settings.clientSecret).to.equal('&');
         });
 
+        it('supports wreck options', async () => {
+
+            const client = new OAuth.Client({ provider: Bell.providers.twitter(), wreck: { baseUrl: 'http://hapi.dev/' } });
+            await expect(client._request('get', '/', null, { oauth_token: 'xcv' }, { secret: 'secret', desc: 'type', stream: true })).to.not.reject();
+        });
+
         describe('_request()', () => {
 
             it('errors on failed request', async () => {


### PR DESCRIPTION
Adds support for passing Wreck options to allow setting agent and other overrides.