### PR TITLE
Support hapi v21 and node v18, drop hapi v19 and node v12, test ESM support

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
+Copyright (c) 2014-2022, Project contributors  
+Copyright (c) 2014-2020, Sideway Inc
 Copyright (c) 2014, Walmart.  
 All rights reserved.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const Providers = require('./providers');
 
 const internals = {
     simulate: false,
-    flexBoolean: Joi.boolean().truthy('true', 'yes', 1, '1').falsy('false', 'no', 0, '0')
+    flexBoolean: Joi.boolean().truthy('yes', 1, '1').falsy('no', 0, '0')
 };
 
 
@@ -25,10 +25,9 @@ exports.oauth = OAuth;
 exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=19.0.0'
+        hapi: '>=20.0.0'
     },
-
-    register: function (server, options) {
+    register: function (server) {
 
         server.auth.scheme('bell', internals.implementation);
         server.expose('oauth', OAuth);
@@ -128,7 +127,7 @@ internals.implementation = function (server, options) {
     // Lookup provider
 
     if (typeof settings.provider === 'object') {
-        settings.name = settings.provider.name || 'custom';
+        settings.name = settings.provider.name ?? 'custom';
     }
     else {
         settings.name = settings.provider;
@@ -157,7 +156,7 @@ internals.implementation = function (server, options) {
         clearInvalid: true
     };
 
-    settings.cookie = settings.cookie || 'bell-' + settings.name;
+    settings.cookie = settings.cookie ?? `bell-${settings.name}`;
     server.state(settings.cookie, cookieOptions);
 
     if (internals.simulate) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -646,7 +646,7 @@ internals.parse = function (payload) {
 internals.location = function (request, protocol, location) {
 
     if (typeof location === 'function') {
-        return location(request) ?? internals.location(request, protocol);
+        return location(request) || internals.location(request, protocol);
     }
 
     if (location) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -196,13 +196,13 @@ exports.v2 = function (settings) {
                 }
             }
 
-            let scope = settings.scope || settings.provider.scope;
+            let scope = settings.scope ?? settings.provider.scope;
             if (typeof scope === 'function') {
                 scope = scope(request);
             }
 
             if (scope) {
-                query.scope = scope.join(settings.provider.scopeSeparator || ' ');
+                query.scope = scope.join(settings.provider.scopeSeparator ?? ' ');
             }
 
             const state = {
@@ -243,7 +243,7 @@ exports.v2 = function (settings) {
         credentials.query = state.query;
         h.unstate(cookie);
 
-        const requestState = request.query.state || '';
+        const requestState = request.query.state ?? '';
         if (state.nonce !== requestState.substr(0, Math.min(requestState.length, internals.nonceLength))) {
             return h.unauthenticated(Boom.internal('Incorrect ' + name + ' state parameter'), { credentials });
         }
@@ -393,7 +393,7 @@ exports.Client = internals.Client = function (options) {
         temporary: internals.Client.baseUri(options.provider.temporary),
         token: internals.Client.baseUri(options.provider.token),
         clientId: options.clientId,
-        clientSecret: options.provider.signatureMethod === 'RSA-SHA1' ? options.clientSecret : internals.encode(options.clientSecret || '') + '&',
+        clientSecret: options.provider.signatureMethod === 'RSA-SHA1' ? options.clientSecret : internals.encode(options.clientSecret ?? '') + '&',
         signatureMethod: options.provider.signatureMethod
     };
 
@@ -474,7 +474,7 @@ internals.Client.prototype._request = async function (method, uri, params, oauth
         return Wreck.request(method, uri, requestOptions);
     }
 
-    const desc = (options.desc || 'resource');
+    const desc = (options.desc ?? 'resource');
     try {
         const { res, payload } = await Wreck[method](uri, requestOptions);
         var result = { payload: payload.toString(), statusCode: res.statusCode };
@@ -646,7 +646,7 @@ internals.parse = function (payload) {
 internals.location = function (request, protocol, location) {
 
     if (typeof location === 'function') {
-        return location(request) || internals.location(request, protocol);
+        return location(request) ?? internals.location(request, protocol);
     }
 
     if (location) {

--- a/lib/providers/azure-legacy.js
+++ b/lib/providers/azure-legacy.js
@@ -5,23 +5,22 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-    const tenantId = options.tenant || 'common';
+    const tenantId = options?.tenant ?? 'common';
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: 'https://login.microsoftonline.com/' + tenantId + '/oauth2/authorize',
-        token: 'https://login.microsoftonline.com/' + tenantId + '/oauth2/token',
+        auth: `https://login.microsoftonline.com/${tenantId}/oauth2/authorize`,
+        token: `https://login.microsoftonline.com/${tenantId}/oauth2/token`,
         scope: ['openid', 'offline_access', 'profile'],
         profile: async function (credentials, params, get) {
 
-            const profile = await get('https://login.microsoftonline.com/' + tenantId + '/openid/userinfo');
+            const profile = await get(`https://login.microsoftonline.com/${tenantId}/openid/userinfo`);
 
             credentials.profile = {
                 id: profile.oid,
                 displayName: profile.name,
-                email: profile.upn || profile.email,
+                email: profile.upn ?? profile.email,
                 raw: profile
             };
         }

--- a/lib/providers/azure.js
+++ b/lib/providers/azure.js
@@ -7,14 +7,13 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-    const tenantId = options.tenant || 'common';
+    const tenantId = options?.tenant ?? 'common';
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: 'https://login.microsoftonline.com/' + tenantId + '/oauth2/v2.0/authorize',
-        token: 'https://login.microsoftonline.com/' + tenantId + '/oauth2/v2.0/token',
+        auth: `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`,
+        token: `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
         scope: [
             'openid',
             'offline_access',       // Enable app to get refresh_tokens
@@ -30,7 +29,7 @@ exports = module.exports = function (options) {
             credentials.profile = {
                 id: profile.id,
                 displayName: profile.displayName,
-                email: profile.userPrincipalName || profile.mail,
+                email: profile.userPrincipalName ?? profile.mail,
                 raw: profile
             };
         }

--- a/lib/providers/cognito.js
+++ b/lib/providers/cognito.js
@@ -17,14 +17,14 @@ exports = module.exports = function (options) {
 
     return {
         protocol: 'oauth2',
-        auth: settings.uri + '/oauth2/authorize',
-        token: settings.uri + '/oauth2/token',
+        auth: `${settings.uri}/oauth2/authorize`,
+        token: `${settings.uri}/oauth2/token`,
         scope: ['openid', 'email', 'profile'],
         scopeSeparator: ' ',
         useParamsAuth: true,
         profile: async function (credentials, params, get) {
 
-            const profile = await get(settings.uri + '/oauth2/userInfo');
+            const profile = await get(`${settings.uri}/oauth2/userInfo`);
 
             credentials.profile = {
                 id: profile.sub,

--- a/lib/providers/digitalocean.js
+++ b/lib/providers/digitalocean.js
@@ -11,8 +11,8 @@ exports = module.exports = function () {
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: digitalOceanUrl + '/authorize',
-        token: digitalOceanUrl + '/token',
+        auth: `${digitalOceanUrl}/authorize`,
+        token: `${digitalOceanUrl}/token`,
         profile: async function (credentials, params, get) {
 
             const profile = await get(digitalOceanUserUrl);

--- a/lib/providers/discord.js
+++ b/lib/providers/discord.js
@@ -23,7 +23,7 @@ exports = module.exports = function () {
                 verified: profile.verified,
                 avatar: {
                     id: profile.avatar,
-                    url: 'https://cdn.discordapp.com/avatars/' + profile.id + '/' + profile.avatar + '.png'
+                    url: `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
                 },
                 raw: profile
             };

--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -14,7 +14,7 @@ exports = module.exports = function (options) {
         fields: 'id,name,email,first_name,last_name,middle_name,picture,gender,link,locale,timezone,updated_time,verified',
         scope: ['email']
     };
-    const settings = Hoek.applyToDefaults(defaults, options || {});
+    const settings = Hoek.applyToDefaults(defaults, options ?? {});
 
     return {
         protocol: 'oauth2',

--- a/lib/providers/foursquare.js
+++ b/lib/providers/foursquare.js
@@ -22,7 +22,7 @@ exports = module.exports = function (options) {
 
             credentials.profile = {
                 id: profile.id,
-                displayName: profile.firstName + ' ' + profile.lastName,
+                displayName: `${profile.firstName} ${profile.lastName}`,
                 name: {
                     first: profile.firstName,
                     last: profile.lastName

--- a/lib/providers/github.js
+++ b/lib/providers/github.js
@@ -5,16 +5,14 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-
-    const uri = options.uri || 'https://github.com';
-    const user = options.uri ? options.uri + '/api/v3/user' : 'https://api.github.com/user';
+    const uri = options?.uri ?? 'https://github.com';
+    const user = options?.uri ? `${options.uri}/api/v3/user` : 'https://api.github.com/user';
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: uri + '/login/oauth/authorize',
-        token: uri + '/login/oauth/access_token',
+        auth: `${uri}/login/oauth/authorize`,
+        token: `${uri}/login/oauth/access_token`,
         scope: ['user:email'],
         scopeSeparator: ',',
         headers: {

--- a/lib/providers/gitlab.js
+++ b/lib/providers/gitlab.js
@@ -5,15 +5,13 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-
-    const uri = options.uri || 'https://gitlab.com';
-    const user = uri + '/api/v3/user';
+    const uri = options?.uri ?? 'https://gitlab.com';
+    const user = `${uri}/api/v3/user`;
 
     return {
         protocol: 'oauth2',
-        auth: uri + '/oauth/authorize',
-        token: uri + '/oauth/token',
+        auth: `${uri}/oauth/authorize`,
+        token: `${uri}/oauth/token`,
         profile: async function (credentials, params, get) {
 
             const profile = await get(user);

--- a/lib/providers/instagram.js
+++ b/lib/providers/instagram.js
@@ -5,8 +5,6 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
@@ -23,7 +21,7 @@ exports = module.exports = function (options) {
                 raw: params.user
             };
 
-            if (options.extendedProfile === false) { // Defaults to true
+            if (options?.extendedProfile === false) { // Defaults to true
                 return;
             }
 

--- a/lib/providers/linkedin.js
+++ b/lib/providers/linkedin.js
@@ -15,11 +15,11 @@ exports = module.exports = function (options) {
         profile: async function (credentials, params, get) {
 
             let fields = '';
-            if (this.providerParams && this.providerParams.fields) {
-                fields = '?projection=' + this.providerParams.fields;
+            if (this.providerParams?.fields) {
+                fields = `?projection=${this.providerParams.fields}`;
             }
 
-            const profile = await get('https://api.linkedin.com/v2/me' + fields);
+            const profile = await get(`https://api.linkedin.com/v2/me${fields}`);
             const email = await get('https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))');
 
             credentials.profile = {

--- a/lib/providers/live.js
+++ b/lib/providers/live.js
@@ -23,7 +23,7 @@ exports = module.exports = function (options) {
                     first: profile.first_name,
                     last: profile.last_name
                 },
-                email: profile.emails && (profile.emails.preferred || profile.emails.account),
+                email: profile.emails?.preferred ?? profile.emails?.account,
                 raw: profile
             };
         }

--- a/lib/providers/okta.js
+++ b/lib/providers/okta.js
@@ -15,16 +15,16 @@ exports = module.exports = function (options) {
 
     const settings = Joi.attempt(options, internals.schema);
 
-    let baseUri = settings.uri + '/oauth2';
+    let baseUri = `${settings.uri}/oauth2`;
     if (settings.authorizationServerId) {
-        baseUri += '/' + settings.authorizationServerId;
+        baseUri += `/${settings.authorizationServerId}`;
     }
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: baseUri + '/v1/authorize',
-        token: baseUri + '/v1/token',
+        auth: `${baseUri}/v1/authorize`,
+        token: `${baseUri}/v1/token`,
         scope: ['profile', 'openid', 'email', 'offline_access'],
         profile: async function (credentials, params, get) {
 

--- a/lib/providers/phabricator.js
+++ b/lib/providers/phabricator.js
@@ -17,8 +17,8 @@ exports = module.exports = function (options) {
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: settings.uri + '/oauthserver/auth/',
-        token: settings.uri + '/oauthserver/token/',
+        auth: `${settings.uri}/oauthserver/auth/`,
+        token: `${settings.uri}/oauthserver/token/`,
         scope: ['whoami'],
         scopeSeparator: ',',
         profile: async function (credentials, params, get) {
@@ -27,7 +27,7 @@ exports = module.exports = function (options) {
                 access_token: credentials.token
             };
 
-            const profile = await get(settings.uri + '/api/user.whoami', query);
+            const profile = await get(`${settings.uri}/api/user.whoami`, query);
 
             credentials.profile = {
                 id: profile.result.phid,

--- a/lib/providers/pingfed.js
+++ b/lib/providers/pingfed.js
@@ -5,20 +5,18 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-
-    const uri = options.uri || 'https://login-dev.ext.hpe.com';
+    const uri = options?.uri ?? 'https://login-dev.ext.hpe.com';
 
     return {
         protocol: 'oauth2',
-        auth: uri + '/as/authorization.oauth2',
-        token: uri + '/as/token.oauth2',
+        auth: `${uri}/as/authorization.oauth2`,
+        token: `${uri}/as/token.oauth2`,
         scope: ['openid', 'email'],
         scopeSeparator: ' ',
         useParamsAuth: true,
         profile: async function (credentials, params, get) {
 
-            const profile = await get(uri + '/idp/userinfo.openid');
+            const profile = await get(`${uri}/idp/userinfo.openid`);
 
             credentials.profile = {
                 id: profile.sub,

--- a/lib/providers/salesforce.js
+++ b/lib/providers/salesforce.js
@@ -23,13 +23,13 @@ internals.defaults = {
 
 exports = module.exports = function (options) {
 
-    const combinedSettings = Hoek.applyToDefaults(internals.defaults, options || {});
+    const combinedSettings = Hoek.applyToDefaults(internals.defaults, options ?? {});
     const settings = Joi.attempt(combinedSettings, internals.schema);
 
     return {
         protocol: 'oauth2',
-        auth: settings.uri + '/services/oauth2/authorize',
-        token: settings.uri + '/services/oauth2/token',
+        auth: `${settings.uri}/services/oauth2/authorize`,
+        token: `${settings.uri}/services/oauth2/token`,
         useParamsAuth: true,
         profile: async function (credentials, params, get) {
 

--- a/lib/providers/spotify.js
+++ b/lib/providers/spotify.js
@@ -5,16 +5,14 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-
-    const uri = options.uri || 'https://accounts.spotify.com';
-    const user = options.uri ? options.uri + '/v1/me' : 'https://api.spotify.com/v1/me';
+    const uri = options?.uri ?? 'https://accounts.spotify.com';
+    const user = options?.uri ? `${options.uri}/v1/me` : 'https://api.spotify.com/v1/me';
 
     return {
         protocol: 'oauth2',
         useParamsAuth: true,
-        auth: uri + '/authorize',
-        token: uri + '/api/token',
+        auth: `${uri}/authorize`,
+        token: `${uri}/api/token`,
         scope: ['user-read-email'],
         scopeSeparator: ',',
         headers: { 'User-Agent': 'hapi-bell-spotify' },

--- a/lib/providers/trakt.js
+++ b/lib/providers/trakt.js
@@ -8,16 +8,15 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-    Hoek.assert(options.apiKey, 'The property "apiKey" is required for the trakt.tv bell provider');
+    Hoek.assert(options?.apiKey, 'The property "apiKey" is required for the trakt.tv bell provider');
 
     const uri = 'https://api.trakt.tv';
-    const user = uri + '/users/me';
+    const user = `${uri}/users/me`;
 
     return {
         protocol: 'oauth2',
-        auth: uri + '/oauth/authorize',
-        token: uri + '/oauth/token',
+        auth: `${uri}/oauth/authorize`,
+        token: `${uri}/oauth/token`,
         headers: {
             'trakt-api-version': 2,
             'trakt-api-key': options.apiKey

--- a/lib/providers/twitter.js
+++ b/lib/providers/twitter.js
@@ -13,7 +13,7 @@ const internals = {
 
 exports = module.exports = function (options) {
 
-    const settings = Hoek.applyToDefaults(internals.defaults, options || {});
+    const settings = Hoek.applyToDefaults(internals.defaults, options ?? {});
 
     return {
         protocol: 'oauth',
@@ -36,7 +36,7 @@ exports = module.exports = function (options) {
                 user_id: params.user_id
             };
 
-            const getParams = Hoek.applyToDefaults(paramDefaults, settings.getParams || {});
+            const getParams = Hoek.applyToDefaults(paramDefaults, settings.getParams ?? {});
 
             const profile = await get(`https://api.twitter.com/1.1/${settings.getMethod}.json`, getParams);
             credentials.profile.displayName = profile.name;

--- a/lib/providers/vk.js
+++ b/lib/providers/vk.js
@@ -5,8 +5,8 @@ const internals = {};
 
 exports = module.exports = function (options) {
 
-    options = options || {};
-    const version = options.version || '5.73';
+    options = options ?? {};
+    const version = options.version ?? '5.73';
     const key_id = parseInt(version) < 5 ? 'uid' : 'id';
 
     return {

--- a/lib/providers/yahoo.js
+++ b/lib/providers/yahoo.js
@@ -13,11 +13,11 @@ exports = module.exports = function (options) {
         token: 'https://api.login.yahoo.com/oauth/v2/get_token',
         profile: async function (credentials, params, get) {
 
-            const profile = await get('https://social.yahooapis.com/v1/user/' + params.xoauth_yahoo_guid + '/profile', { format: 'json' });
+            const profile = await get(`https://social.yahooapis.com/v1/user/${params.xoauth_yahoo_guid}/profile`, { format: 'json' });
 
             credentials.profile = {
                 id: profile.profile.guid,
-                displayName: profile.profile.givenName + ' ' + profile.profile.familyName,
+                displayName: `${profile.profile.givenName} ${profile.profile.familyName}`,
                 name: {
                     first: profile.profile.givenName,
                     last: profile.profile.familyName

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git://github.com/hapijs/bell",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "files": [
     "lib"
@@ -49,20 +49,20 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/cryptiles": "^5.1.0",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/wreck": "17.x.x",
-    "joi": "17.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/cryptiles": "^6.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/wreck": "^18.0.0",
+    "joi": "^17.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/hawk": "8.x.x",
-    "@hapi/lab": "24.x.x",
-    "@hapi/teamwork": "5.x.x"
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/hawk": "^8.0.0",
+    "@hapi/lab": "^25.0.1",
+    "@hapi/teamwork": "^6.0.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -m 3000",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Bell;
+
+    before(async () => {
+
+        Bell = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Bell)).to.equal([
+            'default',
+            'oauth',
+            'plugin',
+            'providers',
+            'simulate'
+        ]);
+    });
+});

--- a/test/mock.js
+++ b/test/mock.js
@@ -31,7 +31,7 @@ exports.v1 = async function (flags, options = {}) {
         server: Hapi.server({ host: 'localhost' })
     };
 
-    mock.options.signatureMethod = mock.options.signatureMethod || 'HMAC-SHA1';
+    mock.options.signatureMethod = mock.options.signatureMethod ?? 'HMAC-SHA1';
 
     mock.server.route([
         {
@@ -226,7 +226,7 @@ exports.v2 = async function (flags, options = {}) {
                         payload.id = 'https://login.salesforce.com/id/foo/bar';
                     }
 
-                    return h.response(payload).code(options.code || 200);
+                    return h.response(payload).code(options.code ?? 200);
                 }
             }
         }
@@ -273,7 +273,7 @@ exports.override = function (uri, payload) {
                 }
 
                 if (payload instanceof Error) {
-                    const statusCode = (payload && payload.output ? payload.output.statusCode : 400);
+                    const statusCode = (payload?.output?.statusCode ?? 400);
                     return { res: { statusCode }, payload: JSON.stringify({ message: payload.message }) };
                 }
 


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19 and below.
 - Support and test on node v18, drop support for node v12 and below.
 - Test ESM support.
 - Utilize some node v14+ new syntax.

If this looks good, this will go out as bell v13.
