### PR TITLE
chore: bump hoek

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,17 +49,17 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "^10.0.0",
-    "@hapi/bounce": "^3.0.0",
-    "@hapi/cryptiles": "^6.0.0",
-    "@hapi/hoek": "^10.0.0",
-    "@hapi/wreck": "^18.0.0",
-    "joi": "^17.0.0"
+    "@hapi/boom": "^10.0.1",
+    "@hapi/bounce": "^3.0.1",
+    "@hapi/cryptiles": "^6.0.1",
+    "@hapi/hoek": "^11.0.2",
+    "@hapi/wreck": "^18.0.1",
+    "joi": "^17.7.1"
   },
   "devDependencies": {
-    "@hapi/code": "^9.0.0",
-    "@hapi/eslint-plugin": "^6.0.0",
-    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/code": "^9.0.3",
+    "@hapi/eslint-plugin": "*",
+    "@hapi/hapi": "^21.2.1",
     "@hapi/hawk": "^8.0.0",
     "@hapi/lab": "^25.0.1",
     "@hapi/teamwork": "^6.0.0"


### PR DESCRIPTION
Needs https://github.com/hapijs/boom/pull/299, https://github.com/hapijs/bounce/pull/35, https://github.com/hapijs/wreck/pull/299 and a new release of cryptiles before merging/releasing.