### PR TITLE
Pass user credentials

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -185,7 +185,7 @@ exports.v2 = function (settings) {
             }
 
             query.client_id = settings.clientId;
-            query.response_type = 'code id_token';
+            query.response_type = 'code';
             query.redirect_uri = internals.location(request, protocol, settings.location);
             query.state = nonce;
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -185,7 +185,7 @@ exports.v2 = function (settings) {
             }
 
             query.client_id = settings.clientId;
-            query.response_type = 'code';
+            query.response_type = 'code id_token';
             query.redirect_uri = internals.location(request, protocol, settings.location);
             query.state = nonce;
 
@@ -313,7 +313,9 @@ exports.v2 = function (settings) {
         credentials.token = payload.access_token;
         credentials.refreshToken = payload.refresh_token;
         credentials.expiresIn = payload.expires_in;
-
+        if (request.query?.user) {
+        credentials.user = request.query.user;    
+        }
         if (!settings.provider.profile || settings.skipProfile) {
             return h.authenticated({ credentials, artifacts: payload });
         }


### PR DESCRIPTION
When you provide `scope` property for apple authentication. Apple responds with the user data in the authentication request and not the authorization request. So this PR aims to provide these values back so it can be used in the `profile` property.

https://dev.to/harryadel/apple-sign-in-using-hapijs-32ik
