### PR TITLE
Add tokenParams option

### DIFF
--- a/API.md
+++ b/API.md
@@ -274,6 +274,10 @@ Each strategy accepts the following optional settings:
         - `uri` - allows pointing to a private enterprise installation (e.g.
           `'https://vpn.example.com'`). See [Providers documentation](https://github.com/hapijs/bell/blob/master/Providers.md) for more
           information.
+- `tokenParams` - provider-specific query parameters for the token endpoint. It may be
+  passed either as an object to merge into the query string, or a function which takes the client's
+  `request` and returns an object. Each provider supports its own set of parameters which customize
+  the user's login experience.
 - `profileParams` - an object of key-value pairs that specify additional URL query parameters to
   send with the profile request to the provider. The built-in `facebook` provider, for example,
   could have `fields` specified to determine the fields returned from the user's graph, which would

--- a/Providers.md
+++ b/Providers.md
@@ -37,11 +37,22 @@ credentials.profile = {
 
 [Provider Documentation](https://auth0.com/docs/protocols#oauth-server-side)
 
-- `scope`: not applicable
+- `scope`: Defaults to `['openid', 'email', 'profile']`
 - `config`:
   - `domain`: Your Auth0 domain name, such as `example.auth0.com` or `example.eu.auth0.com`
 - `auth`: [/authorize](https://auth0.com/docs/auth-api#!#get--authorize_social)
 - `token`: [/oauth/token](https://auth0.com/docs/protocols#3-getting-the-access-token)
+
+To create a token for a specific endpoint, add it to the `providerParams` and `tokenParams` options, eg.:
+
+```js
+providerParams: {
+    endpoint: 'https://api.service.com'
+},
+tokenParams: {
+    endpoint: 'https://api.service.com'
+}
+```
 
 To authenticate a user with a specific identity provider directly, use `providerParams`. For example:
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -126,6 +126,12 @@ export interface OptionalOptions {
         | { uri?: string | undefined }
         | undefined;
     /**
+     * provider-specific query parameters for the token endpoint.
+     * It may be passed either as an object to merge into the query string,
+     * or a function which takes the client's request and returns an object.
+    */
+    tokenParams?: StringLikeMap | ((request: Request) => StringLikeMap) | undefined;
+    /**
      * an object of key-value pairs that specify additional
      * URL query parameters to send with the profile request to the provider.
      * The built-in facebook provider,

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,8 @@ internals.schema = Joi.object({
 
     config: Joi.object(),
 
+    tokenParams: Joi.alternatives(Joi.object(), Joi.func()),
+
     profileParams: Joi.object(),
 
     skipProfile: internals.flexBoolean.optional().default(false),

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -248,7 +248,8 @@ exports.v2 = function (settings) {
         const query = {
             grant_type: 'authorization_code',
             code: request.query.code,
-            redirect_uri: internals.location(request, protocol, settings.location)
+            redirect_uri: internals.location(request, protocol, settings.location),
+            ...internals.resolveProviderParams(request, settings.tokenParams)
         };
 
         if (settings.provider.pkce) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -72,12 +72,11 @@ exports.v1 = function (settings) {
 
             h.state(cookie, state);
 
-            const authQuery = internals.resolveProviderParams(request, settings.providerParams);
-            authQuery.oauth_token = temp.oauth_token;
-
-            if (settings.allowRuntimeProviderParams) {
-                Hoek.merge(authQuery, request.query);
-            }
+            const authQuery = {
+                ...internals.resolveProviderParams(request, settings.providerParams),
+                oauth_token: temp.oauth_token,
+                ...(settings.allowRuntimeProviderParams && request.query)
+            };
 
             return h.redirect(settings.provider.auth + '?' + internals.queryString(authQuery)).takeover();
         }
@@ -123,7 +122,7 @@ exports.v1 = function (settings) {
         const get = async (uri, params = {}) => {
 
             if (settings.profileParams) {
-                Hoek.merge(params, settings.profileParams);
+                Object.assign(params, settings.profileParams);
             }
 
             const { payload: resource } = await client.resource('get', uri, params, { token: token.oauth_token, secret: token.oauth_token_secret });
@@ -178,16 +177,14 @@ exports.v2 = function (settings) {
             credentials.query = request.query;
 
             const nonce = Cryptiles.randomAlphanumString(internals.nonceLength);
-            const query = internals.resolveProviderParams(request, settings.providerParams);
-
-            if (settings.allowRuntimeProviderParams) {
-                Hoek.merge(query, request.query);
-            }
-
-            query.client_id = settings.clientId;
-            query.response_type = 'code';
-            query.redirect_uri = internals.location(request, protocol, settings.location);
-            query.state = nonce;
+            const query = {
+                ...internals.resolveProviderParams(request, settings.providerParams),
+                ...(settings.allowRuntimeProviderParams && request.query),
+                client_id: settings.clientId,
+                response_type: 'code',
+                redirect_uri: internals.location(request, protocol, settings.location),
+                state: nonce
+            };
 
             if (settings.runtimeStateCallback) {
                 const runtimeState = settings.runtimeStateCallback(request);
@@ -731,6 +728,5 @@ internals.getProtocol = function (request, settings) {
 
 internals.resolveProviderParams = function (request, params) {
 
-    const obj = typeof params === 'function' ? params(request) : params;
-    return obj ? Hoek.clone(obj) : {};
+    return (typeof params === 'function' ? params(request) : params) ?? {};
 };

--- a/test/mock.js
+++ b/test/mock.js
@@ -226,6 +226,10 @@ exports.v2 = async function (flags, options = {}) {
                         payload.id = 'https://login.salesforce.com/id/foo/bar';
                     }
 
+                    if (code.client_id === 'endpoint') {
+                        payload.endpoint = request.payload.endpoint;
+                    }
+
                     return h.response(payload).code(options.code ?? 200);
                 }
             }


### PR DESCRIPTION
This mirrors the `providerParams` and `profileParams` options, to allow custom parameters to be supplied to the `token` endpoint request.

This is needed by Auth0, which cannot return a JWT token without the `endpoint` parameter added to both the `/authorize` and `/token` request. More details here: https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens#control-access-token-audience.

Note that the existing `providerParams` option, seems to be confusingly named. I guess `authParams` would be better, but renaming it requires a breaking change.